### PR TITLE
Changed "assets" to "media" for ignoring on Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ core/url/extensions.py
 # Grunt #
 ##########
 node_modules
-assets
+media


### PR DESCRIPTION
Not sure why there was "assets", as all media files are stored inside "media" folder. So that folder must be ignored instead of another.