### PR TITLE
New styling for Overview List

### DIFF
--- a/datagroupings/templatetags/usergroups.py
+++ b/datagroupings/templatetags/usergroups.py
@@ -9,18 +9,24 @@ def get_user_group(group, grouping):
         disabled = 'disabled="disabled"'
 
     if grouping.usergroups.filter(usergroup=group).exists():
-        html = '<div class="overview-list-item">\
-                    <button type="button" name="%s" class="btn btn-default pull-right active grant-single" data-toggle="button" %s><span class="text-danger">Revoke access</span></button><strong>%s</strong><p>%s</p>\
-                </div>' % (
+        html = '<li>\
+                    <button type="button" name="%s" class="btn btn-default \
+                    pull-right active grant-single" data-toggle="button" %s>\
+                    <span class="text-danger">Revoke access</span></button>\
+                    <strong>%s</strong><p>%s</p>\
+                </li>' % (
             group.id,
             disabled,
             group.name,
             group.description
         )
     else:
-        html = '<div class="overview-list-item">\
-                    <button type="button" name="%s" class="btn btn-default pull-right grant-single" data-toggle="button" %s><span class="text-success">Grant access</span></button><strong>%s</strong><p>%s</p>\
-                </div>' % (
+        html = '<li>\
+                    <button type="button" name="%s" class="btn btn-default \
+                    pull-right grant-single" data-toggle="button" %s><span \
+                    class="text-success">Grant access</span></button>\
+                    <strong>%s</strong><p>%s</p>\
+                </li>' % (
             group.id,
             disabled,
             group.name,
@@ -32,8 +38,10 @@ def get_user_group(group, grouping):
 
 @register.simple_tag
 def usergroups(grouping):
-    html = ''
+    html = '<ul class="list-unstyled overview-list">'
     for group in grouping.project.usergroups.all():
         html += get_user_group(group, grouping)
+
+    html += '</ul>'
 
     return html

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -260,30 +260,24 @@ div.well.empty-list {
 	margin-top: 2em;
 }
 
-ul.overview-list > li:not(:first-child):not(:last-child),
-ol.overview-list > li:not(:first-child):not(:last-child) {
-    padding: 1.5em 0;
-    border-top: 1px solid #ddd;
+ul.overview-list > li,
+ol.overview-list > li {
+  padding: 1.5em 0;
+  border-top: 1px solid #ddd;
 }
 
 ul.overview-list > li:first-child,
 ol.overview-list > li:first-child {
-    padding-bottom: 1.5em;
+  padding-top: 0;
+  border-top: none;
 }
 
 ul.overview-list > li:last-child,
 ol.overview-list > li:last-child {
-    padding-top: 1.5em;
-    border-top: 1px solid #ddd;
+  padding-bottom: 0;
 }
 
-div.overview-list-item {
-	display: block;
-	border-top: 1px solid #ddd;
-	padding: 1.5em 0;
-}
-
-div.overview-list-item.checkbox {
+ul.overview-list > li .checkbox {
 	padding-left: 20px;
 	margin-bottom: 0;
 	margin-top: 0;
@@ -291,55 +285,56 @@ div.overview-list-item.checkbox {
 	padding-bottom: 15px;
 }
 
-	div.overview-list-item h3:last-child {
+	ul.overview-list > li h3:last-child,
+	ul.overview-list > li p:last-child {
 		margin-bottom: 0;
 	}
 
-	div.overview-list-item a + h3 {
+	ul.overview-list > li a + h3 {
 		margin-top: 0;
 	}
 
-	div.overview-list-item h3 a {
+	ul.overview-list > li h3 a {
 		text-decoration: none;
 	}
 
-	div.overview-list-item h3 span.label {
+	ul.overview-list > li h3 span.label {
 		font-size: 0.5em;
 	}
 
-	div.overview-list-item p.meta {
+	ul.overview-list > li p.meta {
 		color: #999;
 		margin-bottom: 0;
 		text-transform: uppercase;
 		font-size: 12px;
 	}
 
-	div.overview-list-item p.meta span.lower-case {
+	ul.overview-list > li p.meta span.lower-case {
 		text-transform: none;
 	}
 
-	div.overview-list-item .message {
+	ul.overview-list > li.message {
 		margin-top: -15px;
 		margin-bottom: 15px;
 		padding: 15px;
 	}
 
-div.overview-list-item.ui-sortable-helper {
-	border-bottom: 1px solid #ddd;
-}
+	ul.overview-list > li.ui-sortable-helper {
+		border-bottom: 1px solid #ddd;
+	}
 
-div.ui-state-highlight {
+li.ui-state-highlight {
 	background-color: #fcf8e3;
 	border: 1px dashed #ddd;
 	height: 50px;
 	margin: 15px 0;
 }
 
-div.overview-list-item.sort-item span.glyphicon:hover {
+ul.overview-list > li.sort-item span.glyphicon:hover {
 	cursor: move;
 }
 
-div.overview-list-item.sort-item p {
+ul.overview-list > li.sort-item p {
 	padding-left: 22px;
 }
 
@@ -536,6 +531,7 @@ h6.item-info + h3 {
 
 .message {
 	padding: 15px;
+	margin-bottom: 15px;
 }
 
 #map {

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -260,6 +260,23 @@ div.well.empty-list {
 	margin-top: 2em;
 }
 
+ul.overview-list > li:not(:first-child):not(:last-child),
+ol.overview-list > li:not(:first-child):not(:last-child) {
+    padding: 1.5em 0;
+    border-top: 1px solid #ddd;
+}
+
+ul.overview-list > li:first-child,
+ol.overview-list > li:first-child {
+    padding-bottom: 1.5em;
+}
+
+ul.overview-list > li:last-child,
+ol.overview-list > li:last-child {
+    padding-top: 1.5em;
+    border-top: 1px solid #ddd;
+}
+
 div.overview-list-item {
 	display: block;
 	border-top: 1px solid #ddd;

--- a/templates/applications/application_connected.html
+++ b/templates/applications/application_connected.html
@@ -27,11 +27,20 @@
                         Your connected applications
                     </h3>
                     {% for app in connected_apps %}
-                    <div class="overview-list-item">
+
+                    {% if forloop.first %}
+                    <ul class="list-unstyled overview-list">
+                    {% endif %}
+
+                    <li>
                         <a href="{% url 'admin:app_disconnect' app.id %}" class="btn btn-default pull-right">Disconnect</a>
                         <h3>{{ app.name }}</h3>
                         {% if app.description %}<p>{{app.description}}</p>{% endif %}
-                    </div>
+                    </li>
+
+                    {% if forloop.last %}
+                    </ul>
+                    {% endif %}
                     {% empty %}
                         <div class="well empty-list">
                             <p class="lead">You haven't connected any applications yet.</p>

--- a/templates/applications/application_overview.html
+++ b/templates/applications/application_overview.html
@@ -31,17 +31,26 @@
                 </div>
 
                 <div class="col-md-8">
-                    <h3>
+                    <h3 class="header">
                         Your registered applications
                         {% if apps %}<a href="{% url 'admin:app_register' %}" class="pull-right btn btn-sm btn-success"><span class="glyphicon glyphicon-plus"></span> Create new application</a>{% endif %}
                     </h3>
+
                     {% for app in apps %}
-                    <div class="overview-list-item">
+                    {% if forloop.first %}
+                    <ul class="list-unstyled overview-list">
+                    {% endif %}
+
+                    <li>
                         <h3><a href="{% url 'admin:app_settings' app.id %}">{{app.name}}</a></h3>
                         {% if app.description %}<p>{{app.description}}</p>{% endif %}
                         <p class="meta">Client ID: <span class="lower-case">{{ app.client_id }}</span></p>
                         <p class="meta">Client secret: <span class="lower-case">{{ app.client_secret }}</span></p>
-                    </div>
+                    </li>
+
+                    {% if forloop.last %}
+                    </ul>
+                    {% endif %}
                     {% empty %}
                         <div class="well empty-list">
                             <p class="lead">You haven't registered an application yet.</p>

--- a/templates/categories/category_list.html
+++ b/templates/categories/category_list.html
@@ -26,7 +26,7 @@
 
             <div class="row">
                 <div class="col-sm-8">
-                    <h3>
+                    <h3 class="header">
                         Categories
                         {% if project.categories.all %}
                             <a href="{% url 'admin:category_create' project.id %}" class="btn btn-success btn-sm pull-right"><span class="glyphicon glyphicon-plus"></span> Create new category</a>
@@ -35,16 +35,16 @@
                     {% for category in project.categories.all %}
 
                     {% if forloop.first %}
-                    <div id="sortable">
+                    <ul class="list-unstyled overview-list" id="sortable">
                     {% endif %}
 
-                        <div class="overview-list-item sort-item" data-item-id="{{ category.id }}">
+                        <li class="sort-item" data-item-id="{{ category.id }}">
                             <h4><small><span class="glyphicon glyphicon-sort"></span></small> <a href="{% url 'admin:category_overview' project.id category.id %}">{{category.name}}</a> {% if category.status == 'inactive' %}<small><span class="label label-default">INACTIVE</span></small>{% endif %}</h4>
                             {% if category.description %}<p>{{category.description}}</p>{% endif %}
-                        </div>
+                        </li>
 
                     {% if forloop.last %}
-                    </div>
+                    </ul>
                     {% endif %}
 
                     {% empty %}

--- a/templates/categories/category_overview.html
+++ b/templates/categories/category_overview.html
@@ -40,20 +40,27 @@
                     </div>
                 </div>
                 <div class="col-sm-8">
-                    <h3>
+                    <h3 class="header">
                         Fields
                         {% if category.fields.all %}
                             <a href="{% url 'admin:category_field_create' category.project.id category.id %}" class="btn btn-success btn-sm pull-right"><span class="glyphicon glyphicon-plus"></span> Create new field</a>
                         {% endif %}
                     </h3>
                     {% if category.fields.all %}
-                        <div id="sortable">
                         {% for field in category.fields.all %}
-                            <div class="overview-list-item sort-item" data-item-id="{{ field.id }}">
+                            {% if forloop.first %}
+                            <ul class="list-unstyled overview-list" id="sortable">
+                            {% endif %}
+
+                            <li class="sort-item" data-item-id="{{ field.id }}">
                                 <h4><small><span class="glyphicon glyphicon-sort"></span></small> <a href="{% url 'admin:category_field_settings' category.project.id category.id field.id %}">{{field.name}}</a> {% if field.status == 'inactive' %}<small><span class="label label-default">INACTIVE</span></small>{% endif %}</h4>
                                 {% if field.description %}<p>{{field.description}}</p>{% endif %}
                                 <p class="meta"><strong>Key:</strong> {{ field.key }} &mdash; <strong>Type:</strong> {{ field.type_name }}</p>
-                            </div>
+                            </li>
+
+                            {% if forloop.last %}
+                            </ul>
+                            {% endif %}
                         {% endfor %}
                         </div>
                     {% else %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -12,12 +12,17 @@
             {% include 'snippets/messages.html' %}
             <div class="row">
                 <div class="col-md-8">
-                    <h3>
+                    <h3 class="header">
                         Manage your projects
                         {% if admin_projects %} <a href="{% url 'admin:project_create' %}" class="pull-right btn btn-sm btn-success"><span class="glyphicon glyphicon-plus"></span> Create new Project</a>{% endif %}
                     </h3>
                     {% for project in admin_projects %}
-                    <div class="overview-list-item">
+
+                    {% if forloop.first %}
+                    <ul class="list-unstyled overview-list">
+                    {% endif %}
+
+                    <li>
                         <h3>
                             <a href="{% url 'admin:project_overview' project.id %}">{{project.name}}</a>
                             {% if project.isprivate %}<span class="label label-info">Private</span>{% else %}<span class="label label-info">Public</span>{% endif %}
@@ -25,7 +30,12 @@
                         </h3>
                         {% if project.description %}<p>{{project.description}}</p>{% endif %}
                         <p class="meta">Created by {{ project.creator.display_name }}</p>
-                    </div>
+                    </li>
+
+                    {% if forloop.last %}
+                    </ul>
+                    {% endif %}
+
                     {% empty %}
                         <div class="well empty-list">
                             <p class="lead">We couldn't find any projects you are eligible to manage.</p>

--- a/templates/datagroupings/grouping_list.html
+++ b/templates/datagroupings/grouping_list.html
@@ -24,16 +24,26 @@
 
             <div class="row">
                 <div class="col-sm-8">
-                    <h3>Data groupings
+                    <h3 class="header">Data groupings
                         {% if project.groupings.all %}
                             <a href="{% url 'admin:grouping_create' project.id %}" class="btn btn-sm btn-success pull-right"><span class="glyphicon glyphicon-plus"></span> Create new data grouping</a>
                         {% endif %}
                     </h3>
                     {% for grouping in project.groupings.all %}
-                    <div class="overview-list-item">
+
+                    {% if forloop.first %}
+                    <ul class="list-unstyled overview-list">
+                    {% endif %}
+
+                    <li>
                         <h4><a href="{% url 'admin:grouping_overview' grouping.project.id grouping.id %}">{{grouping.name}}</a></h4>
                         {% if grouping.description %}<p>{{grouping.description}}</p>{% endif %}
-                    </div>
+                    </li>
+
+                    {% if forloop.last %}
+                    </ul>
+                    {% endif %}
+
                     {% empty %}
                         <div class="well empty-list">
                             <p class="lead">We couldn't find any data groupings for this project.</p>

--- a/templates/datagroupings/grouping_overview.html
+++ b/templates/datagroupings/grouping_overview.html
@@ -38,20 +38,28 @@
                     </div>
                 </div>
                 <div class="col-sm-8">
-                    <h3>
+                    <h3 class="header">
                         Filters
                         {% if grouping.rules.all %}
                             <a href="{% url 'admin:rule_create' grouping.project.id grouping.id %}" class="btn btn-success btn-sm pull-right"><span class="glyphicon glyphicon-plus"></span> Create new filter</a>
                         {% endif %}
                     </h3>
                     {% for filter in grouping.rules.all %}
-                    <div class="overview-list-item">
+                    {% if forloop.first %}
+                    <ul class="list-unstyled overview-list">
+                    {% endif %}
+
+                    <li>
 
                         <h4><a href="{% url 'admin:rule_settings' grouping.project.id grouping.id filter.id %}">Contributions of type <strong>{{ filter.category.name }}</strong></a>{% if filter.filters or filter.min_date or filter.max_date %} where {% endif %}</h4>
                         <ul>
                             {% filters filter %}
                         </ul>
-                    </div>
+                    </li>
+
+                    {% if forloop.last %}
+                    </ul>
+                    {% endif %}
                     {% empty %}
                         <div class="well empty-list">
                             <p class="lead">We couldn't find any filters for this data grouping.</p>

--- a/templates/superusertools/projects_list.html
+++ b/templates/superusertools/projects_list.html
@@ -30,10 +30,20 @@
         <div class="col-md-8">
             <h3>Manage all projects</h3>
             {% for project in projects %}
-            <div class="overview-list-item">
+
+            {% if forloop.first %}
+            <ul class="list-unstyled overview-list">
+            {% endif %}
+
+            <li>
                 <h4><a href="{% url 'admin:project_overview' project.id %}">{{ project.name }}</a></h4>
                 {% if project.description %}<p>{{ project.description }}</p>{% endif %}
-            </div>
+            </li>
+
+            {% if forloop.last %}
+            </ul>
+            {% endif %}
+
             {% empty %}
             <div class="well empty-list">
                 <p class="lead">We couldn't find any projects.</p>

--- a/templates/users/usergroup_list.html
+++ b/templates/users/usergroup_list.html
@@ -24,20 +24,22 @@
 
             <div class="row">
                 <div class="col-sm-8">
-                    <h3>
+                    <h3 class="header">
                         User groups
                         <a href="{% url 'admin:usergroup_create' project.id %}" class="btn btn-success btn-sm pull-right"><span class="glyphicon glyphicon-plus"></span> Create new user group</a>
                     </h3>
-                    <div class="overview-list-item">
-                        <h4><a href="{% url 'admin:admins_overview' project.id %}">Administrators</a></h4>
-                        <p>Administrators for the project {{ project.name }}</p>
-                    </div>
-                    {% for group in project.usergroups.all %}
-                    <div class="overview-list-item">
-                        <h4><a href="{% url 'admin:usergroup_overview' group.project.id group.id %}">{{group.name}}</a></h4>
-                        {% if group.description %}<p>{{group.description}}</p>{% endif %}
-                    </div>
-                    {% endfor %}
+                    <ul class="list-unstyled overview-list">
+                        <li>
+                            <h4><a href="{% url 'admin:admins_overview' project.id %}">Administrators</a></h4>
+                            <p>Administrators for the project {{ project.name }}</p>
+                        </li>
+                        {% for group in project.usergroups.all %}
+                        <li>
+                            <h4><a href="{% url 'admin:usergroup_overview' group.project.id group.id %}">{{group.name}}</a></h4>
+                            {% if group.description %}<p>{{group.description}}</p>{% endif %}
+                        </li>
+                        {% endfor %}
+                    </ul>
                 </div>
 
                 <div class="col-sm-4">

--- a/templates/users/usergroup_permissions.html
+++ b/templates/users/usergroup_permissions.html
@@ -76,7 +76,7 @@
                         </div>
                     </form>
 
-                    <h3>
+                    <h3 class="header">
                         Access to data groupings
                         <div class="btn-group pull-right">
                             <button type="button" id="grant-all" class="btn btn-default btn-sm"><span class="text-success">Grant to all groups</span></button>

--- a/users/templatetags/viewgroups.py
+++ b/users/templatetags/viewgroups.py
@@ -9,12 +9,23 @@ def get_view_group(grouping, group):
     message = ''
     if not grouping.project.isprivate and not grouping.isprivate:
         disabled = 'disabled="disabled"'
-        message = '<p class="text-danger">This data grouping is public. To restrict access, navigate to the <a href="%s">data grouping settings</a> and revoke access from the public.</p>' % reverse('admin:grouping_permissions', kwargs={'project_id' :grouping.project.id, 'grouping_id' : grouping.id, })
+        message = '<p class="text-danger">This data grouping is public. To \
+            restrict access, navigate to the <a href="%s">data grouping \
+            settings</a> and revoke access from the public.</p>' % reverse(
+                'admin:grouping_permissions',
+                kwargs={
+                    'project_id': grouping.project.id,
+                    'grouping_id': grouping.id
+                }
+            )
 
     if group.viewgroups.filter(grouping=grouping).exists():
-        return '<div class="overview-list-item">\
-                    %s<button type="button" name="%s" class="btn btn-default pull-right active grant-single" data-toggle="button" %s><span class="text-danger">Revoke access</span></button><strong>%s</strong><p>%s</p>\
-                </div>' % (
+        return '<li>\
+                    %s<button type="button" name="%s" class="btn btn-default \
+                    pull-right active grant-single" data-toggle="button" %s>\
+                    <span class="text-danger">Revoke access</span></button>\
+                    <strong>%s</strong><p>%s</p>\
+                </li>' % (
             message,
             grouping.id,
             disabled,
@@ -22,9 +33,12 @@ def get_view_group(grouping, group):
             grouping.description
         )
     else:
-        return '<div class="overview-list-item">\
-                    %s<button type="button" name="%s" class="btn btn-default pull-right grant-single" data-toggle="button" %s><span class="text-success">Grant access</span></button><strong>%s</strong><p>%s</p>\
-                </div>' % (
+        return '<li>\
+                    %s<button type="button" name="%s" class="btn btn-default \
+                    pull-right grant-single" data-toggle="button" %s><span \
+                    class="text-success">Grant access</span></button>\
+                    <strong>%s</strong><p>%s</p>\
+                </li>' % (
             message,
             grouping.id,
             disabled,
@@ -35,8 +49,10 @@ def get_view_group(grouping, group):
 
 @register.simple_tag
 def viewgroups(group):
-    html = ''
+    html = '<ul class="list-unstyled overview-list">'
     for grouping in group.project.groupings.all():
         html += get_view_group(grouping, group)
+
+    html += '</ul>'
 
     return html


### PR DESCRIPTION
Styling can now be applied to list, e.g. `<ul class="overview-list”>…</ul>` styling each `<li>` including first and list
child.

Top border is applied for each `<li>` but the first. Also, first and last `<li>`'s don't have padding on top and bottom (follows Bootstrap styling, when, for example, "list-unstyled" class is used together.