### PR TITLE
Auto add URLs for each extension

### DIFF
--- a/geokey/core/urls.py
+++ b/geokey/core/urls.py
@@ -11,6 +11,7 @@ urlpatterns = patterns(
     url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     url(r'^admin/account/', include('allauth.urls')),
     url(r'^$', RedirectView.as_view(url='/admin/', permanent=True)),
+    url(r'^', include('geokey.extensions.urls')),
 )
 
 urlpatterns += patterns(

--- a/geokey/extensions/urls.py
+++ b/geokey/extensions/urls.py
@@ -1,0 +1,14 @@
+from django.conf.urls import url, include
+
+from geokey.extensions.base import extensions
+
+
+urlpatterns = []
+
+for extension in extensions:
+    try:
+        urls = '%s.urls' % extension
+        __import__(urls)
+        urlpatterns.append(url(r'^', include(urls, namespace=extension)))
+    except ImportError:
+        pass


### PR DESCRIPTION
No need to include URLs manually.

Additionally, imports only if urls.py is present. Can be useful when adding ability to create extensions without URLs (e.g., various helpers).