### PR TITLE
Permanently activates users

### DIFF
--- a/geokey/superusertools/tests/test_views.py
+++ b/geokey/superusertools/tests/test_views.py
@@ -7,6 +7,8 @@ from django.template.loader import render_to_string
 from django.contrib.sites.shortcuts import get_current_site
 from django.contrib.messages import get_messages
 
+from allauth.account.models import EmailAddress
+
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from geokey import version
@@ -208,8 +210,23 @@ class ManageInactiveUsersTest(TestCase):
 
     def create_inactive(self):
         self.inactive_1 = UserF.create(**{'is_active': False})
+        EmailAddress(
+            user=self.inactive_1,
+            email=self.inactive_1.email,
+            verified=False
+        ).save()
         self.inactive_2 = UserF.create(**{'is_active': False})
+        EmailAddress(
+            user=self.inactive_2,
+            email=self.inactive_2.email,
+            verified=False
+        ).save()
         self.inactive_3 = UserF.create(**{'is_active': False})
+        EmailAddress(
+            user=self.inactive_3,
+            email=self.inactive_3.email,
+            verified=False
+        ).save()
 
     def test_get_with_anonymous(self):
         response = self.view(self.request)
@@ -315,7 +332,12 @@ class ManageInactiveUsersTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode('utf-8'), rendered)
-        self.assertEqual(User.objects.filter(is_active=False).count(), 1)
+        self.assertEqual(
+            User.objects.filter(is_active=False).count(), 1
+        )
+        self.assertEqual(
+            EmailAddress.objects.filter(verified=False).count(), 1
+        )
 
 
 class AddSuperUsersAjaxViewTest(TestCase):

--- a/geokey/superusertools/views.py
+++ b/geokey/superusertools/views.py
@@ -4,6 +4,8 @@ from django.contrib import messages
 
 from braces.views import LoginRequiredMixin
 
+from allauth.account.models import EmailAddress
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import BasePermission
@@ -153,6 +155,11 @@ class ManageInactiveUsers(LoginRequiredMixin, SuperuserMixin, TemplateView):
             activate_users = request.POST.getlist('activate_users')
             to_activate = User.objects.filter(id__in=activate_users)
             to_activate.update(is_active=True)
+
+            for email in EmailAddress.objects.filter(user__in=to_activate):
+                email.verified = True
+                email.set_as_primary(conditional=True)
+                email.save()
 
             messages.success(
                 self.request,

--- a/geokey/templates/superusertools/manage_inactiveusers.html
+++ b/geokey/templates/superusertools/manage_inactiveusers.html
@@ -25,7 +25,7 @@
             <h3 class="header">Manage inactive users</h3>
 
             {% if inactive_users|length %}
-                <p>Select users you would like to activate:</p>
+                <p>Select users you would like to activate by manually confirming their email addresses:</p>
 
                 <div class="form-group">
                     <table class="table table-striped">


### PR DESCRIPTION
Setting “is_active” on a user model is not enough. This now also
changes “verified” in the EmailAddress object and sets them as primary
email addresses.

This does not send an email address informing about user email address
confirmation.