### PR TITLE
Allow Observations with null/None location.

### DIFF
--- a/geokey/contributions/migrations/0016_auto_20151212_1049.py
+++ b/geokey/contributions/migrations/0016_auto_20151212_1049.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0015_auto_20150907_1345'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='observation',
+            name='location',
+            field=models.ForeignKey(related_name='locations', to='contributions.Location', null=True),
+        ),
+    ]

--- a/geokey/contributions/models.py
+++ b/geokey/contributions/models.py
@@ -52,7 +52,7 @@ class Observation(models.Model):
     Stores a single observation.
     """
     location = models.ForeignKey(
-        Location, related_name='locations'
+        Location, related_name='locations',  null=True
     )
     project = models.ForeignKey(
         'projects.Project', related_name='observations'
@@ -182,7 +182,8 @@ class Observation(models.Model):
         if not properties:
             properties = {}
 
-        location.save()
+        if not (location is None):
+            location.save()
         observation = cls.objects.create(
             location=location,
             category=category,


### PR DESCRIPTION
Potentially breaking, but all tests pass.

This relates to `geokey-sapelli` limitation (https://github.com/ExCiteS/geokey-sapelli/issues/11) of only supporting Sapelli projects in which each form has a Location field. In Sapelli itself Location fields are never required and we (= UCL ExCiteS) have a couple of projects floating round with such location-less forms.

More investigation and discussion needed...