### PR TITLE
Category & LookupValue symbols

### DIFF
--- a/geokey/categories/migrations/0014_category_symbol_lookupvalue_symbol.py
+++ b/geokey/categories/migrations/0014_category_symbol_lookupvalue_symbol.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('categories', '0013_auto_20150130_1440'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='lookupvalue',
+            name='symbol',
+            field=models.ImageField(max_length=500, null=True, upload_to=b'symbols'),
+        ),
+        migrations.AlterField(
+            model_name='category',
+            name='symbol',
+            field=models.ImageField(max_length=500, null=True, upload_to=b'symbols'),
+        ),
+    ]

--- a/geokey/categories/models.py
+++ b/geokey/categories/models.py
@@ -40,7 +40,7 @@ class Category(models.Model):
         max_length=20
     )
     colour = models.TextField(default='#0033ff')
-    symbol = models.ImageField(upload_to='symbols', null=True)
+    symbol = models.ImageField(upload_to='symbols', null=True, max_length=500)
 
     objects = CategoryManager()
 
@@ -837,6 +837,7 @@ class LookupValue(models.Model):
     Stores a single lookup value.
     """
     name = models.CharField(max_length=100)
+    symbol = models.ImageField(upload_to='symbols', null=True, max_length=500)
     field = models.ForeignKey(LookupField, related_name='lookupvalues')
     status = models.CharField(
         choices=STATUS,

--- a/geokey/categories/tests/model_factories.py
+++ b/geokey/categories/tests/model_factories.py
@@ -2,6 +2,7 @@ import factory
 
 from geokey.projects.tests.model_factories import ProjectFactory
 from geokey.users.tests.model_factories import UserFactory
+from geokey.core.tests.helpers.image_helpers import get_image
 
 from ..models import (
     Category, TextField, NumericField, DateTimeField, DateField, TimeField,
@@ -110,6 +111,7 @@ class LookupValueFactory(factory.django.DjangoModelFactory):
         model = LookupValue
 
     name = factory.Sequence(lambda n: "lookupfield %s" % n)
+    symbol = get_image(file_name='test_lookup_value_symbol.png')
     field = factory.SubFactory(LookupFieldFactory)
     status = 'active'
 

--- a/geokey/categories/tests/test_manager.py
+++ b/geokey/categories/tests/test_manager.py
@@ -443,6 +443,13 @@ class FieldManagerTest(TestCase):
 
 
 class LookupManagerTest(TestCase):
+    def tearDown(self):
+        for lookup_value in LookupValue.objects.all():
+            try:
+                lookup_value.symbol.delete()
+            except BaseException:
+                pass
+
     def test(self):
         LookupValueFactory.create_batch(5, **{'status': 'active'})
         LookupValueFactory.create_batch(5, **{'status': 'deleted'})

--- a/geokey/categories/tests/test_model.py
+++ b/geokey/categories/tests/test_model.py
@@ -1,11 +1,12 @@
 import json
+
 from django.test import TestCase
 
 from nose.tools import raises
 
 from geokey.core.exceptions import InputError
 
-from ..models import Field, Category
+from ..models import Field, Category, LookupValue
 
 from .model_factories import (
     TextFieldFactory, NumericFieldFactory, DateTimeFieldFactory,
@@ -451,6 +452,13 @@ class NumericFieldTest(TestCase):
 
 
 class SingleLookupFieldTest(TestCase):
+    def tearDown(self):
+        for lookup_value in LookupValue.objects.all():
+            try:
+                lookup_value.symbol.delete()
+            except BaseException:
+                pass
+
     def test_create_lookupfield(self):
         category = CategoryFactory()
         field = Field.create(

--- a/geokey/categories/tests/test_views.py
+++ b/geokey/categories/tests/test_views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 import json
 
 from django.test import TestCase, RequestFactory
@@ -10,7 +11,7 @@ from rest_framework.test import APIRequestFactory, force_authenticate
 from rest_framework import status
 
 from geokey.projects.tests.model_factories import UserFactory, ProjectFactory
-from geokey.contributions.tests.media.model_factories import get_image
+from geokey.core.tests.helpers.image_helpers import get_image
 
 from .model_factories import (
     CategoryFactory, TextFieldFactory, NumericFieldFactory,
@@ -212,9 +213,29 @@ class CategoryDisplayTest(TestCase):
         self.category = CategoryFactory.create(
             **{
                 'project': self.project,
-                'symbol': get_image()
+                'symbol': get_image(file_name='test_category_symbol.png')
             }
         )
+
+    def delete_symbol(self, category):
+        # No idea why this has to be so hard, but this is the only way I got it
+        # to work. Doing category.symbol.delete() does *not* work consistently.
+        symbol = category.symbol
+        try:
+            symbol.file.close()
+        except BaseException:
+            pass
+        try:
+           symbol.storage.delete(symbol.path)
+        except BaseException:
+            pass
+
+    def tearDown(self):
+        self.delete_symbol(self.category)
+        try:
+            self.delete_symbol(Category.objects.get(pk=self.category.id))
+        except Category.DoesNotExist:
+            pass
 
     def get(self, user):
         view = CategoryDisplay.as_view()
@@ -232,7 +253,7 @@ class CategoryDisplayTest(TestCase):
     def post(self, user, clear_symbol='false'):
         self.data = {
             'colour': '#222222',
-            'symbol': get_image() if clear_symbol == 'false' else None,
+            'symbol': get_image(file_name='test_category_symbol.png') if clear_symbol == 'false' else None,
             'clear-symbol': clear_symbol
         }
         view = CategoryDisplay.as_view()
@@ -1308,6 +1329,13 @@ class UpdateNumericField(TestCase):
 
 
 class AddLookupValueTest(TestCase):
+    def tearDown(self):
+        for lookup_value in LookupValue.objects.all():
+            try:
+                lookup_value.symbol.delete()
+            except BaseException, e:
+                pass
+
     def setUp(self):
         self.factory = APIRequestFactory()
         self.admin = UserFactory.create()
@@ -1407,6 +1435,13 @@ class UpdateLookupValues(TestCase):
             'project': self.project,
             'status': 'active'
         })
+
+    def tearDown(self):
+        for lookup_value in LookupValue.objects.all():
+            try:
+                lookup_value.symbol.delete()
+            except BaseException, e:
+                pass
 
     def test_update_lookupvalue_with_admin(self):
         lookup_field = LookupFieldFactory(**{
@@ -1874,6 +1909,13 @@ class ObservationTypePublicApiTest(TestCase):
             'key': 'key_6',
             'category': self.category
         })
+
+    def tearDown(self):
+        for lookup_value in LookupValue.objects.all():
+            try:
+                lookup_value.symbol.delete()
+            except BaseException, e:
+                pass
 
     def _get(self, user):
         url = reverse(

--- a/geokey/contributions/tests/media/model_factories.py
+++ b/geokey/contributions/tests/media/model_factories.py
@@ -1,24 +1,9 @@
 import factory
-from PIL import Image
-from StringIO import StringIO
-
-from django.core.files.base import ContentFile
 
 from geokey.users.tests.model_factories import UserFactory
 from geokey.contributions.tests.model_factories import ObservationFactory
 from geokey.contributions.models import ImageFile, VideoFile
-
-
-def get_image(file_name='test.png', width=200, height=200):
-    image_file = StringIO()
-    image = Image.new('RGBA', size=(width, height), color=(255, 0, 255))
-    image.save(image_file, 'png')
-    image_file.seek(0)
-
-    the_file = ContentFile(image_file.read(), file_name)
-    the_file.content_type = 'image/png'
-
-    return the_file
+from geokey.core.tests.helpers.image_helpers import get_image
 
 
 class ImageFileFactory(factory.django.DjangoModelFactory):

--- a/geokey/contributions/tests/media/test_manager.py
+++ b/geokey/contributions/tests/media/test_manager.py
@@ -11,11 +11,12 @@ from django.conf import settings
 from nose.tools import raises
 
 from geokey.core.exceptions import FileTypeError
+from geokey.core.tests.helpers.image_helpers import get_image
 from geokey.contributions.models import MediaFile
 
 from geokey.contributions.tests.model_factories import ObservationFactory
 from geokey.users.tests.model_factories import UserFactory
-from .model_factories import ImageFileFactory, get_image
+from .model_factories import ImageFileFactory
 
 
 class ModelManagerTest(TestCase):

--- a/geokey/contributions/tests/media/test_views.py
+++ b/geokey/contributions/tests/media/test_views.py
@@ -17,6 +17,7 @@ from rest_framework.test import APIRequestFactory, force_authenticate
 from rest_framework.renderers import JSONRenderer
 
 from geokey.core.exceptions import MalformedRequestData
+from geokey.core.tests.helpers.image_helpers import get_image
 from geokey.projects.tests.model_factories import UserFactory, ProjectFactory
 from geokey.contributions.models import MediaFile
 from geokey.users.models import User
@@ -27,7 +28,7 @@ from geokey.contributions.views.media import (
 )
 
 from ..model_factories import ObservationFactory
-from .model_factories import ImageFileFactory, get_image
+from .model_factories import ImageFileFactory
 
 
 class MediaFileAbstractListAPIViewTest(TestCase):

--- a/geokey/core/tests/helpers/image_helpers.py
+++ b/geokey/core/tests/helpers/image_helpers.py
@@ -1,0 +1,16 @@
+from PIL import Image
+from StringIO import StringIO
+
+from django.core.files.base import ContentFile
+
+
+def get_image(file_name='test.png', width=200, height=200):
+    image_file = StringIO()
+    image = Image.new('RGBA', size=(width, height), color=(255, 0, 255))
+    image.save(image_file, 'png')
+    image_file.seek(0)
+
+    the_file = ContentFile(image_file.read(), file_name)
+    the_file.content_type = 'image/png'
+    
+    return the_file

--- a/geokey/version.py
+++ b/geokey/version.py
@@ -1,4 +1,4 @@
-VERSION = (0, 8, 4, 'final', 0)
+VERSION = (0, 8, 5, 'final', 0)
 
 
 def get_version():


### PR DESCRIPTION
contributions/core:
 - Moved get_image function out of contributions/tests/media/model_factories.py to core/tests/helpers/image_helpers.py so it can be more easily used in different places while avoiding import cycles

categories:
 - Category model: symbol field path now has max_length 500
 - LookupValue mpdel: added symbol field: this is a first step towards supporting a field-value-based symbology mode in Category
 - model_factories.py: use get_image to generate symbol PNGs for LookupValues
 - test_manager.py, test_model.py & test_views.py: proper clean-up of all generated symbol image files in tearDown() methods

Signed-off-by: Matthias Stevens <matthias.stevens@gmail.com>