### PR TITLE
Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,47 @@
 language: python
-python:
-- '2.7'
+
 services:
-- postgresql
+  - postgresql
+
+python:
+  - '2.7'
+
 addons:
   postgresql: '9.4'
+
+env:
+  - DJANGO='>=1.8,<1.9'
+  - DJANGO='>=1.9,<1.10'
+
 virtualenv:
   system_site_packages: true
+
 install:
-- sudo rm /etc/apt/sources.list.d/ubuntugis-stable-source.list
-- sudo apt-get update -y
-- sudo apt-get install python-gdal gdal-bin binutils
-- export C_INCLUDE_PATH=/usr/include/gdal
-- export CPLUS_INCLUDE_PATH=/usr/include/gdal
+  - sudo rm /etc/apt/sources.list.d/ubuntugis-stable-source.list
+  - sudo apt-get update -y
+  - sudo apt-get install python-gdal gdal-bin binutils
+  - export C_INCLUDE_PATH=/usr/include/gdal
+  - export CPLUS_INCLUDE_PATH=/usr/include/gdal
+
 before_script:
-- psql template1 postgres -c "CREATE EXTENSION hstore;"
-- psql -c "CREATE USER django WITH PASSWORD 'django123';" -U postgres
-- psql -c "ALTER ROLE django WITH superuser;" -U postgres
-- psql -c "CREATE DATABASE geokey OWNER django;" -U postgres
-- psql -d geokey -c "CREATE EXTENSION postgis;" -U postgres
-- cp -r local_settings.example local_settings
-- pip install coveralls
-- pip install -r requirements-dev.txt
-- pip install -e .
-- python manage.py migrate
+  - psql template1 postgres -c "CREATE EXTENSION hstore;"
+  - psql -c "CREATE USER django WITH PASSWORD 'django123';" -U postgres
+  - psql -c "ALTER ROLE django WITH superuser;" -U postgres
+  - psql -c "CREATE DATABASE geokey OWNER django;" -U postgres
+  - psql -d geokey -c "CREATE EXTENSION postgis;" -U postgres
+  - cp -r local_settings.example local_settings
+  - pip install coveralls
+  - pip install -r requirements-dev.txt
+  - pip install -e .
+  - pip install django$DJANGO
+  - python manage.py migrate
+
 script:
-- coverage run --source=geokey.applications,geokey.projects,geokey.categories,geokey.contributions,geokey.users,geokey.superusertools,geokey.extensions manage.py test
-after_success: coveralls
+  - coverage run --source=geokey.applications,geokey.projects,geokey.categories,geokey.contributions,geokey.users,geokey.superusertools,geokey.extensions manage.py test
+
+after_success:
+  - coveralls
+
 deploy:
   provider: pypi
   user: excites

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ before_script:
   - pip install -r requirements-dev.txt
   - pip install -e .
   - pip install django$DJANGO
+  - python -c 'import django; print("DJANGO VERSION: %s " % django.get_version())'
+  - python -c 'from geokey.version import get_version; print("GEOKEY VERSION: %s" % get_version())'
   - python manage.py migrate
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_script:
   - psql -c "CREATE DATABASE geokey OWNER django;" -U postgres
   - psql -d geokey -c "CREATE EXTENSION postgis;" -U postgres
   - cp -r local_settings.example local_settings
+  - pip install --upgrade pip
   - pip install coveralls
   - pip install -r requirements-dev.txt
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ before_script:
   - pip install -r requirements-dev.txt
   - pip install -e .
   - pip install django$DJANGO
-  - python -c 'import django; print("DJANGO VERSION: %s " % django.get_version())'
-  - python -c 'from geokey.version import get_version; print("GEOKEY VERSION: %s" % get_version())'
+  - python -c "import django; print('DJANGO %s ' % django.get_version())"
+  - python -c "from geokey.version import get_version; print('GEOKEY %s' % get_version())"
   - python manage.py migrate
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ GeoKey is a platform for participatory mapping, that is developed by `Extreme Ci
 Install for development
 =======================
 
+GeoKey can run on Python 2.7 only. The latest Django 1.8 version is installed by default, although it can also run with Django 1.9).
+
 1. Update your system:
 
 .. code-block:: console

--- a/geokey/core/tests/helpers/render_helpers.py
+++ b/geokey/core/tests/helpers/render_helpers.py
@@ -1,0 +1,6 @@
+from re import sub
+
+
+def remove_csrf(decoded_input):
+    csrf_regex = r'<input[^>]+csrfmiddlewaretoken[^>]+>'
+    return sub(csrf_regex, '', decoded_input)

--- a/geokey/core/url/admin.py
+++ b/geokey/core/url/admin.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from geokey.projects import views as project_views
 from geokey.categories import views as category_views
@@ -8,8 +8,7 @@ from geokey.superusertools import views as superuser
 from geokey.subsets import views as subsets
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', login_views.Index.as_view(), name='index'),
     url(r'^dashboard/$', login_views.Dashboard.as_view(), name='dashboard'),
 
@@ -187,4 +186,4 @@ urlpatterns = patterns(
     url(r'^superuser-tools/manage-inactive-users/$',
         superuser.ManageInactiveUsers.as_view(),
         name="superuser_manage_inactiveusers"),
-)
+]

--- a/geokey/core/url/ajax.py
+++ b/geokey/core/url/ajax.py
@@ -1,12 +1,11 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from geokey.projects import views as project_views
 from geokey.categories import views as category_views
 from geokey.users import views as user_views
 from geokey.superusertools import views as superuser_views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     # ###########################
     # PROJECTS
     # ###########################
@@ -69,4 +68,4 @@ urlpatterns = patterns(
     # ###########################
     url(r'^superusers/$', superuser_views.AddSuperUsersAjaxView.as_view(), name='superusers_adduser'),
     url(r'^superusers/(?P<user_id>[0-9]+)/$', superuser_views.DeleteSuperUsersAjaxView.as_view(), name='superusers_deleteuser'),
-)
+]

--- a/geokey/core/url/api.py
+++ b/geokey/core/url/api.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from geokey.core.views import InfoAPIView
 
@@ -9,8 +9,7 @@ from geokey.contributions.views import observations, comments, locations, media
 from geokey.users.views import UserAPIView, ChangePasswordView
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     # ###########################
     # CORE
     # ###########################
@@ -89,4 +88,4 @@ urlpatterns = patterns(
         r'^projects/(?P<project_id>[0-9]+)/categories/(?P<category_id>[0-9]+)/$',
         category_views.SingleCategory.as_view(),
         name='category'),
-)
+]

--- a/geokey/core/urls.py
+++ b/geokey/core/urls.py
@@ -1,10 +1,10 @@
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
+from django.conf.urls.static import static
 from django.views.generic.base import RedirectView
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^ajax/', include('geokey.core.url.ajax', namespace="ajax")),
     url(r'^admin/', include('geokey.core.url.admin', namespace="admin")),
     url(r'^api/', include('geokey.core.url.api', namespace="api")),
@@ -12,11 +12,4 @@ urlpatterns = patterns(
     url(r'^admin/account/', include('allauth.urls')),
     url(r'^$', RedirectView.as_view(url='/admin/', permanent=True)),
     url(r'^', include('geokey.extensions.urls')),
-)
-
-urlpatterns += patterns(
-    '',
-    (r'^media/(?P<path>.*)$',
-        'django.views.static.serve',
-        {'document_root': settings.MEDIA_ROOT}),
-)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/geokey/subsets/tests/test_views.py
+++ b/geokey/subsets/tests/test_views.py
@@ -10,6 +10,7 @@ from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 
 from geokey import version
+from geokey.core.tests.helpers import render_helpers
 from geokey.users.tests.model_factories import UserFactory
 from geokey.projects.tests.model_factories import ProjectFactory
 from geokey.categories.tests.model_factories import CategoryFactory
@@ -168,7 +169,8 @@ class SubsetCreateTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
     def test_post_with_anonymous(self):
         """
@@ -356,7 +358,8 @@ class SubsetSettingsTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
     def test_get_with_admin(self):
         """
@@ -383,7 +386,8 @@ class SubsetSettingsTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
     def test_get_non_existing_with_admin(self):
         """
@@ -510,7 +514,8 @@ class SubsetSettingsTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
     def test_post_non_existing_with_admin(self):
         """
@@ -728,7 +733,8 @@ class SubsetDataTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
     def test_post_non_existing_with_admin(self):
         """
@@ -805,7 +811,8 @@ class SubsetDataTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
     def test_post_on_project_when_no_categories_with_admin(self):
         """

--- a/geokey/superusertools/tests/test_views.py
+++ b/geokey/superusertools/tests/test_views.py
@@ -12,6 +12,7 @@ from allauth.account.models import EmailAddress
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from geokey import version
+from geokey.core.tests.helpers import render_helpers
 from geokey.users.tests.model_factories import UserFactory
 from geokey.users.models import User
 from geokey.projects.tests.model_factories import ProjectFactory
@@ -307,7 +308,8 @@ class ManageInactiveUsersTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
     def test_post_with_superuser(self):
         user = UserFactory.create(**{'is_superuser': True})
@@ -331,7 +333,8 @@ class ManageInactiveUsersTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
         self.assertEqual(
             User.objects.filter(is_active=False).count(), 1
         )

--- a/geokey/users/tests/test_views.py
+++ b/geokey/users/tests/test_views.py
@@ -19,6 +19,7 @@ from rest_framework import status
 from allauth.account.models import EmailAddress
 
 from geokey import version
+from geokey.core.tests.helpers import render_helpers
 from geokey.applications.tests.model_factories import ApplicationFactory
 from geokey.projects.tests.model_factories import ProjectFactory
 from geokey.categories.tests.model_factories import CategoryFactory
@@ -460,6 +461,7 @@ class UserGroupDataTest(TestCase):
             project_id=usergroup.project.id,
             usergroup_id=usergroup.id
         ).render()
+        response = render_helpers.remove_csrf(unicode(response.content))
 
         rendered = render_to_string(
             'users/usergroup_data.html',
@@ -472,7 +474,7 @@ class UserGroupDataTest(TestCase):
                 'GEOKEY_VERSION': version.get_version()
             }
         )
-        self.assertEqual(unicode(response.content), rendered)
+        self.assertEqual(response, rendered)
 
         request = HttpRequest()
         request.method = 'POST'
@@ -488,6 +490,7 @@ class UserGroupDataTest(TestCase):
             project_id=usergroup.project.id,
             usergroup_id=usergroup.id
         ).render()
+        response = render_helpers.remove_csrf(unicode(response.content))
 
         ref = Group.objects.get(pk=usergroup.id)
 
@@ -502,7 +505,7 @@ class UserGroupDataTest(TestCase):
                 'GEOKEY_VERSION': version.get_version()
             }
         )
-        self.assertEqual(unicode(response.content), rendered)
+        self.assertEqual(response, rendered)
         self.assertIsNone(ref.filters)
 
         category = CategoryFactory.create(**{'project': usergroup.project})
@@ -523,6 +526,7 @@ class UserGroupDataTest(TestCase):
             project_id=usergroup.project.id,
             usergroup_id=usergroup.id
         ).render()
+        response = render_helpers.remove_csrf(unicode(response.content))
 
         ref = Group.objects.get(pk=usergroup.id)
 
@@ -537,7 +541,7 @@ class UserGroupDataTest(TestCase):
                 'GEOKEY_VERSION': version.get_version()
             }
         )
-        self.assertEqual(unicode(response.content), rendered)
+        self.assertEqual(response, rendered)
         self.assertEqual(
             ref.filters,
             json.loads('{ "%s": { } }' % category.id)
@@ -568,6 +572,7 @@ class UserGroupDataTest(TestCase):
             project_id=usergroup.project.id,
             usergroup_id=usergroup.id
         ).render()
+        response = render_helpers.remove_csrf(unicode(response.content))
 
         rendered = render_to_string(
             'users/usergroup_data.html',
@@ -580,7 +585,7 @@ class UserGroupDataTest(TestCase):
                 'GEOKEY_VERSION': version.get_version()
             }
         )
-        self.assertEqual(unicode(response.content), rendered)
+        self.assertEqual(response, rendered)
         self.assertIsNone(Group.objects.get(pk=usergroup.id).filters)
 
     def test_views_with_other_user(self):
@@ -601,6 +606,7 @@ class UserGroupDataTest(TestCase):
             project_id=usergroup.project.id,
             usergroup_id=usergroup.id
         ).render()
+        response = render_helpers.remove_csrf(unicode(response.content))
 
         rendered = render_to_string(
             'users/usergroup_data.html',
@@ -613,7 +619,7 @@ class UserGroupDataTest(TestCase):
                 'GEOKEY_VERSION': version.get_version()
             }
         )
-        self.assertEqual(unicode(response.content), rendered)
+        self.assertEqual(response, rendered)
 
         category = CategoryFactory.create(**{'project': usergroup.project})
         request = HttpRequest()
@@ -633,6 +639,7 @@ class UserGroupDataTest(TestCase):
             project_id=usergroup.project.id,
             usergroup_id=usergroup.id
         ).render()
+        response = render_helpers.remove_csrf(unicode(response.content))
 
         rendered = render_to_string(
             'users/usergroup_data.html',
@@ -645,7 +652,7 @@ class UserGroupDataTest(TestCase):
                 'GEOKEY_VERSION': version.get_version()
             }
         )
-        self.assertEqual(unicode(response.content), rendered)
+        self.assertEqual(response, rendered)
         self.assertIsNone(Group.objects.get(pk=usergroup.id).filters)
 
 
@@ -797,7 +804,8 @@ class UserProfileTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
     def test_post_with_anonymous_user(self):
         """
@@ -843,7 +851,8 @@ class UserProfileTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
         reference = User.objects.get(pk=self.request.user.id)
         self.assertEqual(
@@ -891,7 +900,8 @@ class UserProfileTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
         reference = EmailAddress.objects.get(user=self.request.user)
         self.assertEqual(reference.verified, True)
@@ -925,7 +935,8 @@ class UserProfileTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        response = render_helpers.remove_csrf(response.content.decode('utf-8'))
+        self.assertEqual(response, rendered)
 
         reference = User.objects.get(pk=self.request.user.id)
         self.assertEqual(
@@ -959,7 +970,10 @@ class UserProfileTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        self.assertEqual(
+            render_helpers.remove_csrf(response.content.decode('utf-8')),
+            rendered
+        )
 
         self.assertEqual(
             EmailAddress.objects.filter(user=self.request.user).exists(),
@@ -982,7 +996,10 @@ class UserProfileTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), rendered)
+        self.assertEqual(
+            render_helpers.remove_csrf(response.content.decode('utf-8')),
+            rendered
+        )
 
         reference = User.objects.get(pk=self.request.user.id)
         self.assertEqual(

--- a/local_settings.example/urls.py
+++ b/local_settings.example/urls.py
@@ -3,12 +3,11 @@
 # from django.conf import settings
 # from django.conf.urls.static import static
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^', include('geokey.core.urls')),
-)  # + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+]  # + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 # Activate the following two lines if you are running GeoKey using
 # the test server and plan on uploading files via the API.


### PR DESCRIPTION
Tests are set up and code is improved to be able to run on Django 1.9. However, we will still require Django 1.8 by default with a possibility to manually update it to 1.9.

This closes https://github.com/ExCiteS/geokey/issues/332.