### PR TITLE
Get all extensions (whether you're a regular user, or a superuser)

### DIFF
--- a/geokey/core/tests/test_views.py
+++ b/geokey/core/tests/test_views.py
@@ -8,7 +8,6 @@ from django.contrib.auth.models import AnonymousUser
 
 from geokey.version import get_version
 from geokey.core.views import InfoAPIView
-from geokey.users.tests.model_factories import UserFactory
 from geokey.extensions.base import register, deregister
 
 
@@ -45,47 +44,9 @@ class InfoAPIViewTest(TestCase):
 
         return False
 
-    def test_get_with_anonymous(self):
-        """Test GET with anonymous user."""
+    def test_get(self):
+        """Test GET."""
         self.request.user = AnonymousUser()
-        response = self.view(self.request).render()
-
-        self.assertEqual(response.status_code, 200)
-
-        response = json.loads(response.content)
-        self.assertIn('geokey', response)
-
-        geokey = response.get('geokey')
-        self.assertEqual(geokey.get('version'), get_version())
-        self.assertIn('installed_extensions', geokey)
-
-        installed_extensions = geokey.get('installed_extensions')
-        self.assertTrue(self.contains_extension('A', installed_extensions))
-        self.assertTrue(self.contains_extension('B', installed_extensions))
-        self.assertFalse(self.contains_extension('S', installed_extensions))
-
-    def test_get_with_user(self):
-        """Test GET with user."""
-        self.request.user = UserFactory.create(**{'is_superuser': False})
-        response = self.view(self.request).render()
-
-        self.assertEqual(response.status_code, 200)
-
-        response = json.loads(response.content)
-        self.assertIn('geokey', response)
-
-        geokey = response.get('geokey')
-        self.assertEqual(geokey.get('version'), get_version())
-        self.assertIn('installed_extensions', geokey)
-
-        installed_extensions = geokey.get('installed_extensions')
-        self.assertTrue(self.contains_extension('A', installed_extensions))
-        self.assertTrue(self.contains_extension('B', installed_extensions))
-        self.assertFalse(self.contains_extension('S', installed_extensions))
-
-    def test_get_with_superuser(self):
-        """Test GET with superuser."""
-        self.request.user = UserFactory.create(**{'is_superuser': True})
         response = self.view(self.request).render()
 
         self.assertEqual(response.status_code, 200)

--- a/geokey/core/views.py
+++ b/geokey/core/views.py
@@ -39,11 +39,7 @@ class InfoAPIView(APIView):
                 'name': ext_id,
                 'version': ext['version'] if 'version' in ext else None
             },
-            filter(
-                lambda (ext_id, ext):
-                    request.user.is_superuser or not ext['superuser'],
-                extensions.iteritems()
-            )
+            extensions.iteritems()
         )
 
         return Response(info)


### PR DESCRIPTION
The API endpoint has been modified so that it returns a list of all extensions added to GeoKey to every user no matter what status he/she is (including extensions for superusers too).