### PR TITLE
Expiry date for contributions

### DIFF
--- a/geokey/categories/migrations/0017_category_expiry_field.py
+++ b/geokey/categories/migrations/0017_category_expiry_field.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('categories', '0016_multiplelookupvalue_symbol'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='category',
+            name='expiry_field',
+            field=models.ForeignKey(related_name='expiry_field_of', to='categories.Field', null=True),
+        ),
+    ]

--- a/geokey/categories/mixins.py
+++ b/geokey/categories/mixins.py
@@ -60,6 +60,8 @@ class FieldMixin(object):
             project=field.category.project,
             category=field.category,
             field=field,
+            is_display_field=(field == field.category.display_field),
+            is_expiry_field=(field == field.category.expiry_field),
             *args,
             **kwargs
         )

--- a/geokey/categories/models.py
+++ b/geokey/categories/models.py
@@ -36,6 +36,11 @@ class Category(models.Model):
         null=True,
         related_name='display_field_of'
     )
+    expiry_field = models.ForeignKey(
+        'categories.Field',
+        null=True,
+        related_name='expiry_field_of'
+    )
     default_status = models.CharField(
         choices=DEFAULT_STATUS,
         default=DEFAULT_STATUS.pending,

--- a/geokey/categories/templatetags/filter_fields.py
+++ b/geokey/categories/templatetags/filter_fields.py
@@ -7,10 +7,12 @@ register = template.Library()
 
 
 @register.filter
-def only_fields(fields, type_name):
-    return [field for field in fields if field.type_name == type_name]
+def only_fields(fields, type_names):
+    type_names = [type_name.strip() for type_name in type_names.split(",")]
+    return [field for field in fields if field.type_name in type_names]
 
 
 @register.filter
-def except_fields(fields, type_name):
-    return [field for field in fields if field.type_name != type_name]
+def except_fields(fields, type_names):
+    type_names = [type_name.strip() for type_name in type_names.split(",")]
+    return [field for field in fields if field.type_name not in type_names]

--- a/geokey/categories/templatetags/filter_fields.py
+++ b/geokey/categories/templatetags/filter_fields.py
@@ -8,11 +8,11 @@ register = template.Library()
 
 @register.filter
 def only_fields(fields, type_names):
-    type_names = [type_name.strip() for type_name in type_names.split(",")]
+    type_names = [type_name.strip() for type_name in type_names.split(',')]
     return [field for field in fields if field.type_name in type_names]
 
 
 @register.filter
 def except_fields(fields, type_names):
-    type_names = [type_name.strip() for type_name in type_names.split(",")]
+    type_names = [type_name.strip() for type_name in type_names.split(',')]
     return [field for field in fields if field.type_name not in type_names]

--- a/geokey/categories/templatetags/filter_fields.py
+++ b/geokey/categories/templatetags/filter_fields.py
@@ -1,0 +1,16 @@
+"""Template tags for filtering fields."""
+
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter
+def only_fields(fields, type_name):
+    return [field for field in fields if field.type_name == type_name]
+
+
+@register.filter
+def except_fields(fields, type_name):
+    return [field for field in fields if field.type_name != type_name]

--- a/geokey/categories/tests/model_factories.py
+++ b/geokey/categories/tests/model_factories.py
@@ -112,7 +112,7 @@ class LookupValueFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = LookupValue
 
-    name = factory.Sequence(lambda n: 'lookupfield %s' % n)
+    name = factory.Sequence(lambda n: 'lookupvalue %s' % n)
     symbol = get_image(file_name='test_lookup_value_symbol.png')
     field = factory.SubFactory(LookupFieldFactory)
     status = 'active'
@@ -122,8 +122,8 @@ class MultipleLookupFieldFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = MultipleLookupField
 
-    name = factory.Sequence(lambda n: 'lookupfield %s' % n)
-    key = factory.Sequence(lambda n: 'lookupfield_%s' % n)
+    name = factory.Sequence(lambda n: 'multiplelookupfield %s' % n)
+    key = factory.Sequence(lambda n: 'multiplelookupfield_%s' % n)
     description = factory.LazyAttribute(lambda o: '%s description' % o.name)
     category = factory.SubFactory(CategoryFactory)
     status = 'active'
@@ -134,7 +134,7 @@ class MultipleLookupValueFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = MultipleLookupValue
 
-    name = factory.Sequence(lambda n: 'lookupfield %s' % n)
+    name = factory.Sequence(lambda n: 'multiplelookupvalue %s' % n)
     symbol = get_image(file_name='test_lookup_value_symbol.png')
     field = factory.SubFactory(MultipleLookupFieldFactory)
     status = 'active'

--- a/geokey/categories/tests/test_templatetags.py
+++ b/geokey/categories/tests/test_templatetags.py
@@ -1,0 +1,77 @@
+"""Tests for template tags of categories."""
+
+from django.test import TestCase
+
+from geokey.categories.templatetags import filter_fields
+from geokey.categories.tests.model_factories import (
+    CategoryFactory,
+    TextFieldFactory,
+    NumericFieldFactory,
+    DateTimeFieldFactory,
+    DateFieldFactory,
+    TimeFieldFactory,
+    LookupFieldFactory,
+    MultipleLookupFieldFactory
+)
+
+
+class OnlyFieldsTest(TestCase):
+
+    def test_only_fields(self):
+        category = CategoryFactory()
+        TextFieldFactory(category=category)
+        NumericFieldFactory(category=category)
+        DateTimeFieldFactory(category=category)
+        DateFieldFactory(category=category)
+        TimeFieldFactory(category=category)
+        LookupFieldFactory(category=category)
+        MultipleLookupFieldFactory(category=category)
+
+        all_fields = category.fields.all()
+
+        type_names = [
+            'Text',
+            'Numeric',
+            'Date and Time',
+            'Date',
+            'Time',
+            'Select box',
+            'Multiple select'
+        ]
+
+        for type_name in type_names:
+            date_fields = filter_fields.only_fields(all_fields, type_name)
+            self.assertEqual(len(date_fields), 1)
+            for field in date_fields:
+                self.assertEqual(field.type_name, type_name)
+
+
+class ExceptFieldsTest(TestCase):
+
+    def test_except_fields(self):
+        category = CategoryFactory()
+        TextFieldFactory(category=category)
+        NumericFieldFactory(category=category)
+        DateTimeFieldFactory(category=category)
+        DateFieldFactory(category=category)
+        TimeFieldFactory(category=category)
+        LookupFieldFactory(category=category)
+        MultipleLookupFieldFactory(category=category)
+
+        all_fields = category.fields.all()
+
+        type_names = [
+            'Text',
+            'Numeric',
+            'Date and Time',
+            'Date',
+            'Time',
+            'Select box',
+            'Multiple select'
+        ]
+
+        for type_name in type_names:
+            date_fields = filter_fields.except_fields(all_fields, type_name)
+            self.assertEqual(len(date_fields), len(type_names) - 1)
+            for field in date_fields:
+                self.assertNotEqual(field.type_name, type_name)

--- a/geokey/categories/tests/test_templatetags.py
+++ b/geokey/categories/tests/test_templatetags.py
@@ -45,6 +45,14 @@ class OnlyFieldsTest(TestCase):
             for field in date_fields:
                 self.assertEqual(field.type_name, type_name)
 
+        date_fields = filter_fields.only_fields(
+            all_fields,
+            (', ').join(type_names)
+        )
+        self.assertEqual(len(date_fields), len(type_names))
+        for field in date_fields:
+                self.assertTrue(field.type_name in type_names)
+
 
 class ExceptFieldsTest(TestCase):
 
@@ -75,3 +83,9 @@ class ExceptFieldsTest(TestCase):
             self.assertEqual(len(date_fields), len(type_names) - 1)
             for field in date_fields:
                 self.assertNotEqual(field.type_name, type_name)
+
+        date_fields = filter_fields.except_fields(
+            all_fields,
+            (', ').join(type_names)
+        )
+        self.assertEqual(len(date_fields), 0)

--- a/geokey/categories/tests/test_views.py
+++ b/geokey/categories/tests/test_views.py
@@ -473,7 +473,7 @@ class CategorySettingsTest(TestCase):
         field_1 = DateFieldFactory.create(**{'category': self.category})
         field_2 = DateFieldFactory.create(**{'category': self.category})
 
-        self.category.display_field = field_1
+        self.category.expiry_field = field_1
         self.category.save()
 
         response = self.post(self.admin, expiry_field=field_2.id)
@@ -493,7 +493,7 @@ class CategorySettingsTest(TestCase):
     def test_update_settings_when_clearing_expiryfield(self):
         field = DateFieldFactory.create(**{'category': self.category})
 
-        self.category.display_field = field
+        self.category.expiry_field = field
         self.category.save()
 
         response = self.post(self.admin, expiry_field=None)

--- a/geokey/categories/views.py
+++ b/geokey/categories/views.py
@@ -207,7 +207,15 @@ class CategorySettings(LoginRequiredMixin, CategoryMixin, TemplateView):
                 except:
                     expiry_field = None
 
-                if category.expiry_field != expiry_field:
+                if (expiry_field and
+                        expiry_field.type_name not in [
+                        'Date and Time',
+                        'Date']):
+                    messages.error(
+                        self.request,
+                        'Only `Date and Time` and `Date` fields can be used.'
+                    )
+                elif category.expiry_field != expiry_field:
                     category.expiry_field = expiry_field
 
             category.save()

--- a/geokey/categories/views.py
+++ b/geokey/categories/views.py
@@ -189,15 +189,26 @@ class CategorySettings(LoginRequiredMixin, CategoryMixin, TemplateView):
             category.default_status = data.get('default_status')
 
             if category.fields.exists():
-                display_field = category.fields.get(
-                    pk=data.get('display_field')
-                )
-
+                display_field = data.get('display_field')
+                if display_field:
+                    display_field = category.fields.get(
+                        pk=data.get('display_field'))
+                else:
+                    display_field = None
                 if category.display_field != display_field:
                     category.display_field = display_field
                     for observation in category.observation_set.all():
                         observation.update_display_field()
                         observation.save()
+
+                expiry_field = data.get('expiry_field')
+                if expiry_field:
+                    expiry_field = category.fields.get(
+                        pk=data.get('expiry_field'))
+                else:
+                    expiry_field = None
+                if category.expiry_field != expiry_field:
+                    category.expiry_field = expiry_field
 
             category.save()
             messages.success(self.request, 'The category has been updated.')

--- a/geokey/categories/views.py
+++ b/geokey/categories/views.py
@@ -189,24 +189,24 @@ class CategorySettings(LoginRequiredMixin, CategoryMixin, TemplateView):
             category.default_status = data.get('default_status')
 
             if category.fields.exists():
-                display_field = data.get('display_field')
-                if display_field:
+                try:
                     display_field = category.fields.get(
                         pk=data.get('display_field'))
-                else:
+                except:
                     display_field = None
+
                 if category.display_field != display_field:
                     category.display_field = display_field
                     for observation in category.observation_set.all():
                         observation.update_display_field()
                         observation.save()
 
-                expiry_field = data.get('expiry_field')
-                if expiry_field:
+                try:
                     expiry_field = category.fields.get(
                         pk=data.get('expiry_field'))
-                else:
+                except:
                     expiry_field = None
+
                 if category.expiry_field != expiry_field:
                     category.expiry_field = expiry_field
 

--- a/geokey/categories/views.py
+++ b/geokey/categories/views.py
@@ -217,6 +217,9 @@ class CategorySettings(LoginRequiredMixin, CategoryMixin, TemplateView):
                     )
                 elif category.expiry_field != expiry_field:
                     category.expiry_field = expiry_field
+                    for observation in category.observation_set.all():
+                        observation.update_expiry_field()
+                        observation.save()
 
             category.save()
             messages.success(self.request, 'The category has been updated.')

--- a/geokey/categories/views.py
+++ b/geokey/categories/views.py
@@ -474,6 +474,8 @@ class FieldSettings(LoginRequiredMixin, FieldMixin, TemplateView):
             context['status_types'] = STATUS
             context['is_display_field'] = (
                 context['field'] == context['field'].category.display_field)
+            context['is_expiry_field'] = (
+                context['field'] == context['field'].category.expiry_field)
 
         return context
 

--- a/geokey/contributions/migrations/0017_auto_20160531_1434.py
+++ b/geokey/contributions/migrations/0017_auto_20160531_1434.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0016_audiofile'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicalobservation',
+            name='expiry_field',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='observation',
+            name='expiry_field',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+    ]

--- a/geokey/contributions/models.py
+++ b/geokey/contributions/models.py
@@ -240,8 +240,9 @@ class Observation(models.Model):
         display field property
         """
         display_field = self.category.display_field
-        if display_field is not None:
-            value = None
+        value = None
+
+        if display_field:
             if self.properties:
                 value = self.properties.get(display_field.key)
 

--- a/geokey/contributions/models.py
+++ b/geokey/contributions/models.py
@@ -4,6 +4,8 @@ import re
 
 from pytz import utc
 from datetime import datetime
+from iso8601 import parse_date
+from iso8601.iso8601 import ParseError
 
 from django.db import models
 from django.conf import settings
@@ -85,6 +87,7 @@ class Observation(models.Model):
     version = models.IntegerField(default=1)
     search_index = models.TextField(null=True, blank=True)
     display_field = models.TextField(null=True, blank=True)
+    expiry_field = models.DateTimeField(null=True, blank=True)
     num_media = models.IntegerField(default=0)
     num_comments = models.IntegerField(default=0)
 
@@ -244,6 +247,24 @@ class Observation(models.Model):
 
             self.display_field = '%s:%s' % (display_field.key, value)
 
+    def update_expiry_field(self):
+        """
+        Updates the expiry_field attribute. It uses the expiry field of the
+        contributions category and sets the date according to the value set
+        for the current contribution.
+        """
+        expiry_field = self.category.expiry_field
+        if expiry_field is not None:
+            value = None
+            if self.properties:
+                value = self.properties.get(expiry_field.key)
+                try:
+                    value = parse_date(value)
+                except ParseError:
+                    value = None
+
+            self.expiry_field = value
+
     def update_count(self):
         """
         Updates the count of media files attached and comments. Should be
@@ -301,10 +322,11 @@ class Observation(models.Model):
 def pre_save_observation_update(sender, **kwargs):
     """
     Receiver that is called before an observation is saved. Updates
-    search_index and display_field properties.
+    `search_index`, `display_field`, `expiry_field` properties.
     """
     observation = kwargs.get('instance')
     observation.update_display_field()
+    observation.update_expiry_field()
     observation.create_search_index()
 
 

--- a/geokey/contributions/models.py
+++ b/geokey/contributions/models.py
@@ -255,16 +255,15 @@ class Observation(models.Model):
         for the current contribution.
         """
         expiry_field = self.category.expiry_field
-        if expiry_field is not None:
-            value = None
-            if self.properties:
-                value = self.properties.get(expiry_field.key)
-                try:
-                    value = parse_date(value)
-                except ParseError:
-                    value = None
+        value = None
 
-            self.expiry_field = value
+        if expiry_field and self.properties:
+            try:
+                value = parse_date(self.properties.get(expiry_field.key))
+            except ParseError:
+                pass
+
+        self.expiry_field = value
 
     def update_count(self):
         """

--- a/geokey/contributions/serializers.py
+++ b/geokey/contributions/serializers.py
@@ -356,7 +356,7 @@ class ContributionSerializer(BaseSerializer):
         Returns
         -------
         dict
-            serialised display_field; e.g.
+            serialised display_field; e.g.:
             {
                 'key': 'field_key',
                 'value': 'The value of the field'
@@ -371,6 +371,22 @@ class ContributionSerializer(BaseSerializer):
             }
         else:
             return None
+
+    def get_expiry_field(self, obj):
+        """
+        Returns a native representation of the expiry_field property.
+
+        Parameter
+        ---------
+        obj : geokey.contributions.models.Observation
+            The instance that is serialised
+
+        Returns
+        -------
+        dict
+            serialised expiry_field; e.g.: '2016-06-02 10:41:52.929103+00:00'
+        """
+        return str(obj.expiry_field) if obj.expiry_field else None
 
     def to_representation(self, obj):
         """
@@ -403,6 +419,7 @@ class ContributionSerializer(BaseSerializer):
             'id': obj.id,
             'properties': obj.properties,
             'display_field': self.get_display_field(obj),
+            'expiry_field': self.get_expiry_field(obj),
             'meta': {
                 'status': obj.status,
                 'creator': {

--- a/geokey/contributions/views/observations.py
+++ b/geokey/contributions/views/observations.py
@@ -118,7 +118,7 @@ class ProjectObservations(GZipView, GeoJsonView):
 
 # ############################################################################
 #
-# SINGLE CONTRIBUTIONS
+# SINGLE CONTRIBUTION
 #
 # ############################################################################
 

--- a/geokey/projects/models.py
+++ b/geokey/projects/models.py
@@ -1,8 +1,5 @@
 """Models for projects."""
 
-from pytz import utc
-from datetime import datetime
-
 from django.db import models
 from django.conf import settings
 from django.contrib.gis.db import models as gis
@@ -279,12 +276,7 @@ class Project(models.Model):
             List of geokey.contributions.models.Observations
         """
         is_admin = self.is_admin(user)
-
-        # Leave only contributions that hasn't expired or withouts expiry date
-        data = self.observations.filter(
-            models.Q(expiry_field__isnull=True) |
-            models.Q(expiry_field__gt=datetime.utcnow().replace(tzinfo=utc))
-        )
+        data = self.observations
 
         if is_admin or self.can_moderate(user):
             data = data.for_moderator(user)

--- a/geokey/projects/tests/test_models.py
+++ b/geokey/projects/tests/test_models.py
@@ -2,7 +2,7 @@
 
 import pytz
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser
@@ -447,7 +447,19 @@ class ProjectGetDataTest(TestCase):
             'category': category_3}
         )
 
-        self.assertEqual(project.get_all_contributions(user).count(), 15)
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+        ObservationFactory.create(**{
+            'project': project,
+            'category': category_3,
+            'expiry_field': now - timedelta(1)
+        })
+        ObservationFactory.create(**{
+            'project': project,
+            'category': category_3,
+            'expiry_field': now + timedelta(1)
+        })
+
+        self.assertEqual(project.get_all_contributions(user).count(), 16)
 
     def test_get_data_category_filter(self):
         user = UserFactory.create()
@@ -469,22 +481,28 @@ class ProjectGetDataTest(TestCase):
                 'project': project,
                 'category': category_1}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'status': 'pending'}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2}
             )
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
+            })
+
         self.assertEqual(project.get_all_contributions(user).count(), 10)
 
     def test_get_data_subset(self):
@@ -505,22 +523,28 @@ class ProjectGetDataTest(TestCase):
                 'project': project,
                 'category': category_1}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'status': 'pending'}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2}
             )
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
+            })
+
         self.assertEqual(
             project.get_all_contributions(user, subset=subset.id).count(),
             10
@@ -552,22 +576,28 @@ class ProjectGetDataTest(TestCase):
                 'project': project,
                 'category': category_1}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'status': 'pending'}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2}
             )
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_2,
+                'expiry_field': a_day_ago
+            })
+
         self.assertEqual(
             project.get_all_contributions(user, subset=subset.id).count(),
             0
@@ -595,23 +625,29 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'text': 'blah'}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'text': 'blub'}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'status': 'pending'}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2}
             )
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
+            })
+
         self.assertEqual(
             project.get_all_contributions(user, search='blah').count(),
             5
@@ -646,25 +682,30 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'text': 'yes %s' % x}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'status': 'pending',
                 'properties': {'text': 'yes %s' % x}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'text': 'no %s' % x}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': 'yes %s' % x}}
             )
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
+            })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
 
@@ -696,18 +737,24 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'number': 12}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'number': 20}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'number': 12}}
             )
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
+            })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
 
@@ -739,18 +786,24 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'number': 12}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'number': 20}}
             )
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'number': 12}}
             )
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
+            })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
 
@@ -787,30 +840,34 @@ class ProjectGetDataTest(TestCase):
                     'category': category_1,
                     'properties': {'number': 5}}
                 )
-
                 ObservationFactory.create(**{
                     'project': project,
                     'category': category_1,
                     'properties': {'number': 12}}
                 )
-
                 ObservationFactory.create(**{
                     'project': project,
                     'category': category_1,
                     'properties': {'number': 20}}
                 )
-
                 ObservationFactory.create(**{
                     'project': project,
                     'category': category_1,
                     'properties': {'number': 25}}
                 )
-
                 ObservationFactory.create(**{
                     'project': project,
                     'category': category_2,
                     'properties': {'number': 12}}
                 )
+
+                a_day_ago = datetime.utcnow().replace(
+                    tzinfo=pytz.utc) - timedelta(1)
+                ObservationFactory.create(**{
+                    'project': project,
+                    'category': category_1,
+                    'expiry_field': a_day_ago
+                })
 
             self.assertEqual(project.get_all_contributions(user).count(), 10)
 
@@ -857,18 +914,25 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'lookup': lookup_1.id}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'lookup': lookup_2.id}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': lookup_3.id}
             })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
+            })
+
         self.assertEqual(project.get_all_contributions(user).count(), 10)
 
     def test_get_data_min_max_datetime_filter(self):
@@ -903,17 +967,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'date': '2014-04-09'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'date': '2013-04-09'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': '2014-04-09'}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -950,17 +1020,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'date': '2014-04-09'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'date': '2013-04-09'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': '2014-04-09'}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -996,17 +1072,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'date': '2014-04-09'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'date': '2013-04-09'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': '2014-04-09'}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1042,17 +1124,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'date': '2014-04-09'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'date': '2013-04-09'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': '2014-04-09'}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1088,17 +1176,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'time': '11:00'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'time': '18:00'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': '11:00'}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1134,17 +1228,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'time': '2:00'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'time': '18:00'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': '2:00'}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1180,17 +1280,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'time': '11:00'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'time': '18:00'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': '11:00'}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1226,17 +1332,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'time': '11:00'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'time': '18:00'}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': '11:00'}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1424,17 +1536,23 @@ class ProjectGetDataTest(TestCase):
                 'category': category_1,
                 'properties': {'lookup': [lookup_1.id, lookup_3.id]}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
                 'properties': {'lookup': [lookup_2.id, lookup_3.id]}
             })
-
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
                 'properties': {'bla': [lookup_4.id]}
+            })
+
+            a_day_ago = datetime.utcnow().replace(
+                tzinfo=pytz.utc) - timedelta(1)
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'expiry_field': a_day_ago
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 10)

--- a/geokey/projects/tests/test_models.py
+++ b/geokey/projects/tests/test_models.py
@@ -28,7 +28,6 @@ from ..models import Project
 class CreateProjectTest(TestCase):
     def test_create_project(self):
         creator = UserFactory.create()
-
         project = Project.create(
             'Test', 'Test desc', True, False, True, creator
         )
@@ -425,9 +424,14 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_with_none_rule(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         category_2 = CategoryFactory(**{'project': project})
         category_3 = CategoryFactory(**{'project': project})
+
+        expiry_field = DateFieldFactory.create(**{'category': category_3})
+        category_3.expiry_field = expiry_field
+        category_3.save()
 
         UserGroupFactory.create(
             add_users=[user],
@@ -451,12 +455,16 @@ class ProjectGetDataTest(TestCase):
         ObservationFactory.create(**{
             'project': project,
             'category': category_3,
-            'expiry_field': now - timedelta(1)
+            'properties': {
+                expiry_field.key: str(now - timedelta(1))
+            }
         })
         ObservationFactory.create(**{
             'project': project,
             'category': category_3,
-            'expiry_field': now + timedelta(1)
+            'properties': {
+                expiry_field.key: str(now + timedelta(1))
+            }
         })
 
         self.assertEqual(project.get_all_contributions(user).count(), 16)
@@ -466,6 +474,9 @@ class ProjectGetDataTest(TestCase):
         project = ProjectFactory.create()
 
         category_1 = CategoryFactory(**{'project': project})
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
 
         UserGroupFactory.create(
@@ -476,6 +487,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -494,13 +507,12 @@ class ProjectGetDataTest(TestCase):
                 'project': project,
                 'category': category_2}
             )
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 10)
@@ -511,12 +523,17 @@ class ProjectGetDataTest(TestCase):
 
         category_1 = CategoryFactory(**{'project': project})
         TextFieldFactory.create(**{'key': 'text', 'category': category_1})
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
 
         subset = SubsetFactory.create(**{
             'project': project,
             'filters': {category_1.id: {}}
         })
+
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
 
         for x in range(0, 5):
             ObservationFactory.create(**{
@@ -536,13 +553,12 @@ class ProjectGetDataTest(TestCase):
                 'project': project,
                 'category': category_2}
             )
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(
@@ -557,6 +573,9 @@ class ProjectGetDataTest(TestCase):
         category_1 = CategoryFactory(**{'project': project})
         TextFieldFactory.create(**{'key': 'text', 'category': category_1})
         category_2 = CategoryFactory(**{'project': project})
+        expiry_field = DateFieldFactory.create(**{'category': category_2})
+        category_2.expiry_field = expiry_field
+        category_2.save()
 
         UserGroupFactory.create(
             add_users=[user],
@@ -570,6 +589,8 @@ class ProjectGetDataTest(TestCase):
             'project': project,
             'filters': {category_1.id: {}}
         })
+
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
 
         for x in range(0, 5):
             ObservationFactory.create(**{
@@ -589,13 +610,12 @@ class ProjectGetDataTest(TestCase):
                 'project': project,
                 'category': category_2}
             )
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_2,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(
@@ -609,6 +629,9 @@ class ProjectGetDataTest(TestCase):
 
         category_1 = CategoryFactory(**{'project': project})
         TextFieldFactory.create(**{'key': 'text', 'category': category_1})
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
 
         UserGroupFactory.create(
@@ -618,6 +641,8 @@ class ProjectGetDataTest(TestCase):
                 'filters': {category_1.id: {}}
             }
         )
+
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
 
         for x in range(0, 5):
             ObservationFactory.create(**{
@@ -639,13 +664,12 @@ class ProjectGetDataTest(TestCase):
                 'project': project,
                 'category': category_2}
             )
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(
@@ -662,6 +686,9 @@ class ProjectGetDataTest(TestCase):
             'key': 'text',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         TextFieldFactory(**{
             'key': 'bla',
@@ -675,6 +702,8 @@ class ProjectGetDataTest(TestCase):
                 'filters': {category_1.id: {'text': 'yes'}}
             }
         )
+
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
 
         for x in range(0, 5):
             ObservationFactory.create(**{
@@ -698,13 +727,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': 'yes %s' % x}}
             )
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -712,11 +740,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_min_number_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         NumericFieldFactory.create(**{
             'key': 'number',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         NumericFieldFactory.create(**{
             'key': 'bla',
@@ -731,6 +763,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -747,13 +781,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'number': 12}}
             )
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -761,11 +794,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_max_number_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         NumericFieldFactory.create(**{
             'key': 'number',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         NumericFieldFactory.create(**{
             'key': 'bla',
@@ -780,6 +817,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -796,86 +835,90 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'number': 12}}
             )
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
 
     def test_get_data_min_max_number_filter(self):
-            user = UserFactory.create()
-            project = ProjectFactory.create()
-            category_1 = CategoryFactory(**{'project': project})
-            NumericFieldFactory.create(**{
-                'key': 'number',
-                'category': category_1
-            })
-            category_2 = CategoryFactory(**{'project': project})
-            NumericFieldFactory.create(**{
-                'key': 'bla',
-                'category': category_2
-            })
+        user = UserFactory.create()
+        project = ProjectFactory.create()
 
-            UserGroupFactory.create(
-                add_users=[user],
-                **{
-                    'project': project,
-                    'filters': {
-                        category_1.id: {'number': {
-                            'minval': '10',
-                            'maxval': '22'
-                        }}
-                    }
+        category_1 = CategoryFactory(**{'project': project})
+        NumericFieldFactory.create(**{
+            'key': 'number',
+            'category': category_1
+        })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
+        category_2 = CategoryFactory(**{'project': project})
+        NumericFieldFactory.create(**{
+            'key': 'bla',
+            'category': category_2
+        })
+
+        UserGroupFactory.create(
+            add_users=[user],
+            **{
+                'project': project,
+                'filters': {
+                    category_1.id: {'number': {
+                        'minval': '10',
+                        'maxval': '22'
+                    }}
                 }
+            }
+        )
+
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
+        for x in range(0, 5):
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'properties': {'number': 5}}
             )
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'properties': {'number': 12}}
+            )
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'properties': {'number': 20}}
+            )
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'properties': {'number': 25}}
+            )
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_2,
+                'properties': {'number': 12}}
+            )
+            ObservationFactory.create(**{
+                'project': project,
+                'category': category_1,
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
+            })
 
-            for x in range(0, 5):
-                ObservationFactory.create(**{
-                    'project': project,
-                    'category': category_1,
-                    'properties': {'number': 5}}
-                )
-                ObservationFactory.create(**{
-                    'project': project,
-                    'category': category_1,
-                    'properties': {'number': 12}}
-                )
-                ObservationFactory.create(**{
-                    'project': project,
-                    'category': category_1,
-                    'properties': {'number': 20}}
-                )
-                ObservationFactory.create(**{
-                    'project': project,
-                    'category': category_1,
-                    'properties': {'number': 25}}
-                )
-                ObservationFactory.create(**{
-                    'project': project,
-                    'category': category_2,
-                    'properties': {'number': 12}}
-                )
-
-                a_day_ago = datetime.utcnow().replace(
-                    tzinfo=pytz.utc) - timedelta(1)
-                ObservationFactory.create(**{
-                    'project': project,
-                    'category': category_1,
-                    'expiry_field': a_day_ago
-                })
-
-            self.assertEqual(project.get_all_contributions(user).count(), 10)
+        self.assertEqual(project.get_all_contributions(user).count(), 10)
 
     def test_get_data_lookup_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
-        category_1 = CategoryFactory(**{'project': project})
 
+        category_1 = CategoryFactory(**{'project': project})
         lookup_field = LookupFieldFactory(**{
             'key': 'lookup',
             'category': category_1
@@ -888,6 +931,9 @@ class ProjectGetDataTest(TestCase):
             'name': 'Kermit',
             'field': lookup_field
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         lookup_field_2 = LookupFieldFactory(**{
             'key': 'bla',
@@ -908,6 +954,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -924,13 +972,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': lookup_3.id}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 10)
@@ -938,11 +985,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_min_max_datetime_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         DateTimeFieldFactory(**{
             'key': 'date',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         DateTimeFieldFactory(**{
             'key': 'bla',
@@ -961,6 +1012,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -977,13 +1030,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': '2014-04-09'}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -991,11 +1043,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_min_max_date_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         DateFieldFactory(**{
             'key': 'date',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         DateFieldFactory(**{
             'key': 'bla',
@@ -1014,6 +1070,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -1030,13 +1088,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': '2014-04-09'}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1044,11 +1101,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_min_date_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         DateFieldFactory(**{
             'key': 'date',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         DateFieldFactory(**{
             'key': 'bla',
@@ -1066,6 +1127,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -1082,13 +1145,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': '2014-04-09'}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1096,11 +1158,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_max_date_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         DateFieldFactory(**{
             'key': 'date',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         DateFieldFactory(**{
             'key': 'bla',
@@ -1118,6 +1184,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -1134,13 +1202,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': '2014-04-09'}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1148,11 +1215,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_min_max_time_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         TimeFieldFactory(**{
             'key': 'time',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         TimeFieldFactory(**{
             'key': 'bla',
@@ -1170,6 +1241,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -1186,13 +1259,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': '11:00'}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1200,11 +1272,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_min_max_inverse_time_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         TimeFieldFactory(**{
             'key': 'time',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         TimeFieldFactory(**{
             'key': 'bla',
@@ -1222,6 +1298,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -1238,13 +1316,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': '2:00'}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1252,11 +1329,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_min_time_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         TimeFieldFactory(**{
             'key': 'time',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         TimeFieldFactory(**{
             'key': 'bla',
@@ -1274,6 +1355,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -1290,13 +1373,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': '11:00'}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1304,11 +1386,15 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_max_time_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         TimeFieldFactory(**{
             'key': 'time',
             'category': category_1
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         TimeFieldFactory(**{
             'key': 'bla',
@@ -1326,6 +1412,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -1342,13 +1430,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': '11:00'}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 5)
@@ -1356,14 +1443,14 @@ class ProjectGetDataTest(TestCase):
     def test_get_created_after(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
-        category_1 = CategoryFactory(**{'project': project})
+        category = CategoryFactory(**{'project': project})
 
         UserGroupFactory.create(
             add_users=[user],
             **{
                 'project': project,
                 'filters': {
-                    category_1.id: {
+                    category.id: {
                         'min_date': '2013-05-01 00:00:00'}
                 }
             }
@@ -1371,7 +1458,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1380,7 +1467,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1389,7 +1476,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1401,14 +1488,14 @@ class ProjectGetDataTest(TestCase):
     def test_get_created_before(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
-        category_1 = CategoryFactory(**{'project': project})
+        category = CategoryFactory(**{'project': project})
 
         UserGroupFactory.create(
             add_users=[user],
             **{
                 'project': project,
                 'filters': {
-                    category_1.id: {
+                    category.id: {
                         'max_date': '2013-05-01 00:00:00'}
                 }
             }
@@ -1416,7 +1503,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1425,7 +1512,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1434,7 +1521,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1446,14 +1533,14 @@ class ProjectGetDataTest(TestCase):
     def test_get_created_before_and_after(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
-        category_1 = CategoryFactory(**{'project': project})
+        category = CategoryFactory(**{'project': project})
 
         UserGroupFactory.create(
             add_users=[user],
             **{
                 'project': project,
                 'filters': {
-                    category_1.id: {
+                    category.id: {
                         'min_date': '2013-01-01 00:00:00',
                         'max_date': '2013-10-01 00:00:00'}
                 }
@@ -1462,7 +1549,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1471,7 +1558,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1480,7 +1567,7 @@ class ProjectGetDataTest(TestCase):
 
         obs = ObservationFactory.create_batch(5, **{
             'project': project,
-            'category': category_1
+            'category': category
         })
 
         for o in obs:
@@ -1492,6 +1579,7 @@ class ProjectGetDataTest(TestCase):
     def test_get_data_multiple_lookup_filter(self):
         user = UserFactory.create()
         project = ProjectFactory.create()
+
         category_1 = CategoryFactory(**{'project': project})
         lookup_field = MultipleLookupFieldFactory(**{
             'key': 'lookup',
@@ -1509,6 +1597,9 @@ class ProjectGetDataTest(TestCase):
             'name': 'Gonzo',
             'field': lookup_field
         })
+        expiry_field = DateFieldFactory.create(**{'category': category_1})
+        category_1.expiry_field = expiry_field
+        category_1.save()
         category_2 = CategoryFactory(**{'project': project})
         lookup_field_2 = MultipleLookupFieldFactory(**{
             'key': 'bla',
@@ -1530,6 +1621,8 @@ class ProjectGetDataTest(TestCase):
             }
         )
 
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
         for x in range(0, 5):
             ObservationFactory.create(**{
                 'project': project,
@@ -1546,13 +1639,12 @@ class ProjectGetDataTest(TestCase):
                 'category': category_2,
                 'properties': {'bla': [lookup_4.id]}
             })
-
-            a_day_ago = datetime.utcnow().replace(
-                tzinfo=pytz.utc) - timedelta(1)
             ObservationFactory.create(**{
                 'project': project,
                 'category': category_1,
-                'expiry_field': a_day_ago
+                'properties': {
+                    expiry_field.key: str(now - timedelta(1))
+                }
             })
 
         self.assertEqual(project.get_all_contributions(user).count(), 10)

--- a/geokey/templates/categories/category_settings.html
+++ b/geokey/templates/categories/category_settings.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load filter_fields %}
 
 {% block bodydata %}
 data-project-id="{{ project.id }}"
@@ -56,6 +57,23 @@ data-category-id="{{ category.id }}"
                             </select>
                         {% else %}
                             <p class="form-control-static">No fields have been added to the category. <a href="{% url 'admin:category_field_create' category.project.id category.id %}">Add a field</a> to make it the display field for this category.</p>
+                        {% endif %}
+                    {% endwith %}
+                </div>
+
+                <div class="form-group">
+                    <label for="expiry_field" class="control-label">Expiry field</label>
+
+                    {% with fields=category.fields.all|only_fields:'Date and Time, Date' %}
+                        {% if fields %}
+                            <select name="expiry_field" class="form-control input-lg">
+                                <option value=""></option>
+                                {% for field in fields %}
+                                <option value="{{ field.id }}" {% if category.expiry_field.id == field.id%}selected{% endif %}>{{ field.name }}</option>
+                                {% endfor %}
+                            </select>
+                        {% else %}
+                            <p class="form-control-static">No date fields have been added to the category. <a href="{% url 'admin:category_field_create' category.project.id category.id %}">Add a date field</a> to make it the expiry field for this category.</p>
                         {% endif %}
                     {% endwith %}
                 </div>

--- a/geokey/templates/categories/category_settings.html
+++ b/geokey/templates/categories/category_settings.html
@@ -45,7 +45,7 @@ data-category-id="{{ category.id }}"
                 </div>
 
                 <div class="form-group">
-                    <label for="description" class="control-label">Display field</label>
+                    <label for="display_field" class="control-label">Display field</label>
 
                     {% with fields=category.fields.all %}
                         {% if fields %}

--- a/geokey/templates/categories/field_settings.html
+++ b/geokey/templates/categories/field_settings.html
@@ -125,13 +125,24 @@ data-field-id="{{ field.id }}"
                 <div class="panel-heading">
                     <h2 class="panel-title">Be careful!</h2>
                 </div>
+
                 {% if is_display_field %}
                 <div class="panel-body becareful">
                     <div>
                         <p><strong>The field {{ field.name }} is set as display field for category {{ field.category.name }}.</strong> If you wish to deactivate or delete the field, you have to select another display field in the <a href="{% url 'admin:category_settings' field.category.project.id field.category.id %}">category settings</a> first.</p>
                     </div>
                 </div>
-                {% else %}
+                {% endif %}
+
+                {% if is_expiry_field %}
+                <div class="panel-body becareful">
+                    <div>
+                        <p><strong>The field {{ field.name }} is set as expiry field for category {{ field.category.name }}.</strong> If you wish to deactivate or delete the field, you have to select another expiry field in the <a href="{% url 'admin:category_settings' field.category.project.id field.category.id %}">category settings</a> first.</p>
+                    </div>
+                </div>
+                {% endif %}
+
+                {% if not is_display_field and not is_expiry_field %}
                 <div class="panel-body becareful">
                     <div class="toggle-active {% if field.status == status_types.inactive %} hidden{% endif %}">
                         <strong>Make the field inactive</strong>


### PR DESCRIPTION
Each category can now have an expiry field set, which is then used to determine when contributions should expire.

When expired, contributions will not be returned by the API for regular users. However, administrators/moderators and creators of those contributions will still be able to retrieve and change the date if necessary.

None of the data is being deleted when expired, so when the field has changed, or the property for that field is changed, the data is then back for viewing.