### PR TITLE
Requirements update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ django-pgjson==0.3.1
 django-simple-history==1.8.2
 django-youtube==0.2
 django-nose==1.4.4
-djangorestframework==3.6.2
+djangorestframework==3.6.3
 djangorestframework-gis==0.11
 easy-thumbnails==2.3
 gdata==2.0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ moment==0.6.1
 pillow==4.1.1
 psycopg2==2.7.1
 pytz==2017.2
-requests==2.13.0
+requests==2.14.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ gdata==2.0.18
 iso8601==0.1.11
 moment==0.6.1
 pillow==4.1.1
-psycopg2==2.7
+psycopg2==2.7.1
 pytz==2016.10
 requests==2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-simple-history==1.8.2
 django-youtube==0.2
 django-nose==1.4.4
 djangorestframework==3.6.3
-djangorestframework-gis==0.11
+djangorestframework-gis==0.11.1
 easy-thumbnails==2.3
 gdata==2.0.18
 iso8601==0.1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ easy-thumbnails==2.4.1
 gdata==2.0.18
 iso8601==0.1.11
 moment==0.6.1
-pillow==4.0.0
+pillow==4.1.1
 psycopg2==2.7
 pytz==2016.10
 requests==2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-aggregate-if==0.5
 django-allauth==0.32.0
 django-braces==1.11.0
 django-hstore==1.4.2
-django-model-utils==3.0.0
+django-model-utils==2.6.1
 django-oauth-toolkit==0.12.0
 django-pgjson==0.3.1
 django-simple-history==1.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=1.8,<1.10
 django-aggregate-if==0.5
-django-allauth==0.31.0
+django-allauth==0.32.0
 django-braces==1.11.0
 django-hstore==1.4.2
 django-model-utils==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-youtube==0.2
 django-nose==1.4.4
 djangorestframework==3.6.3
 djangorestframework-gis==0.11.1
-easy-thumbnails==2.3
+easy-thumbnails==2.4.1
 gdata==2.0.18
 iso8601==0.1.11
 moment==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-aggregate-if==0.5
 django-allauth==0.32.0
 django-braces==1.11.0
 django-hstore==1.4.2
-django-model-utils==2.6.1
+django-model-utils==3.0.0
 django-oauth-toolkit==0.12.0
 django-pgjson==0.3.1
 django-simple-history==1.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,14 +3,14 @@ django-aggregate-if==0.5
 django-allauth==0.32.0
 django-braces==1.11.0
 django-hstore==1.4.2
-django-model-utils==3.0.0
+django-model-utils==2.6.1
 django-oauth-toolkit==0.12.0
 django-pgjson==0.3.1
 django-simple-history==1.8.2
 django-youtube==0.2
 django-nose==1.4.4
 djangorestframework==3.6.3
-djangorestframework-gis==0.11.1
+djangorestframework-gis==0.11
 easy-thumbnails==2.3
 gdata==2.0.18
 iso8601==0.1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ iso8601==0.1.11
 moment==0.6.1
 pillow==4.1.1
 psycopg2==2.7.1
-pytz==2016.10
+pytz==2017.2
 requests==2.13.0


### PR DESCRIPTION
Following dependencies have been upgraded to::

- django-allauth v0.32.0
- djangorestframework v3.6.3
- djangorestgramwork-gis v0.11.1
- easy-thumbnails v2.4.1
- pillow v4.1.1
- psycopg2 v2.7.1
- pytz 2017,2
- request 2.14.2

I have tried to upgraded django-models-utils to v3.0.0 but test fails for django 1.9 for some "filter" on Fields Models.


