### PR TITLE
Auth contrib only

### DIFF
--- a/geokey/context_processors.py
+++ b/geokey/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def allowed_contributors(request):
+    """Allows access to settings constants within templates."""
+    _ = request  # PEP-8 compliance without reducing readability.
+    # return the value you want as a dictionary. you may add multiple values in there.
+    return {'ALLOWED_CONTRIBUTORS': settings.ALLOWED_CONTRIBUTORS}

--- a/geokey/projects/base.py
+++ b/geokey/projects/base.py
@@ -2,6 +2,7 @@
 
 from model_utils import Choices
 
+from local_settings.settings import ALLOWED_CONTRIBUTORS
 
 STATUS = Choices('active', 'inactive', 'deleted')
-EVERYONE_CONTRIBUTES = Choices('true', 'auth', 'false')
+EVERYONE_CONTRIBUTES = Choices(*ALLOWED_CONTRIBUTORS)

--- a/geokey/projects/models.py
+++ b/geokey/projects/models.py
@@ -323,6 +323,7 @@ class Admins(models.Model):
     An Administator group for a project. Represents the relation between
     Project and User.
     """
+    objects = None
     project = models.ForeignKey('Project', related_name='admin_of')
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/geokey/projects/tests/test_views.py
+++ b/geokey/projects/tests/test_views.py
@@ -85,6 +85,18 @@ class ProjectCreateTest(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(Project.objects.count(), 0)
 
+    def test_get_with_auth(self):
+        expected_text = 'This includes anonymous contributions'
+        with self.settings(ALLOWED_CONTRIBUTORS=tuple(['true', 'auth', 'false'])):
+            view = ProjectCreate.as_view()
+            url = reverse('admin:project_create')
+            request = APIRequestFactory().get(url)
+            request.user = UserFactory.create()
+            response = view(request).render()
+            # self.assertEquals(settings.ALLOWED_CONTRIBUTORS, tuple('thing'), msg=settings.ALLOWED_CONTRIBUTORS)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response=response, text=expected_text, status_code=200)
+
 
 class ProjectsInvolvedTest(TestCase):
     def test_get_with_user(self):

--- a/geokey/projects/tests/test_views.py
+++ b/geokey/projects/tests/test_views.py
@@ -2,7 +2,7 @@
 
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect
@@ -25,13 +25,31 @@ from ..views import (
     ProjectDelete
 )
 
+
 # ############################################################################
 #
 # ADMIN VIEWS
 #
 # ############################################################################
 
-
+@override_settings(
+    TEMPLATES=[
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                    'geokey.context_processors.allowed_contributors',
+                ],
+            },
+        },
+    ]
+)
 class ProjectCreateTest(TestCase):
     def test_get_with_user(self):
         view = ProjectCreate.as_view()

--- a/geokey/templates/projects/project_create.html
+++ b/geokey/templates/projects/project_create.html
@@ -50,11 +50,13 @@
                 <label for="everyone_contributes" class="control-label">Project permissions</label>
 
                 <div class="radio public hidden">
+                    {% if 'true' in ALLOWED_CONTRIBUTORS %}
                     <label>
                         <input type="radio" name="everyone_contributes" value="true" />
                         <strong>All users</strong>
                         <p>All users can contribute. This includes anonymous contributions from users, who are not logged in.</p>
                     </label>
+                    {% endif %}
                 </div>
 
                 <div class="radio">

--- a/local_settings.example/settings.py
+++ b/local_settings.example/settings.py
@@ -60,3 +60,6 @@ ALLOWED_HOSTS = ['*']
 #   auth - Only registered users can contribute.
 #   false - Only users of the contributors group can contribute
 ALLOWED_CONTRIBUTORS = ("true", "auth", "false")
+
+# Allows access to settings within templates.
+TEMPLATES[0]['OPTIONS']['context_processors'][:0] = ['geokey.context_processors.allowed_contributors']

--- a/local_settings.example/settings.py
+++ b/local_settings.example/settings.py
@@ -54,3 +54,9 @@ WSGI_APPLICATION = 'local_settings.wsgi.application'
 
 # Allow all hosts
 ALLOWED_HOSTS = ['*']
+
+# Specify what kind of user contributions an admin can allow for a project.
+#   true - All users (including anonymous users) can contribute
+#   auth - Only registered users can contribute.
+#   false - Only users of the contributors group can contribute
+ALLOWED_CONTRIBUTORS = ("true", "auth", "false")


### PR DESCRIPTION
In order to make it impossible for admins to make projects which allow anonymous contributions, this must now be set with the ALLOWED_CONTRIBUTORS constant in settings.py. This is required for WGN.

Note:
- All local settings.py will need to be updated to include this constant.
- The option to disallow other kinds of contributors are not implemented and probably won't be needed.