### PR TITLE
Check that data member is correct type

### DIFF
--- a/geokey/projects/models.py
+++ b/geokey/projects/models.py
@@ -98,6 +98,7 @@ class Project(models.Model):
         We are not allowing anonymous contributions for private projects.
         """
         if (self.isprivate and
+                type(self.everyone_contributes) == str and
                 self.everyone_contributes == EVERYONE_CONTRIBUTES.true):
             self.everyone_contributes = EVERYONE_CONTRIBUTES.auth
 


### PR DESCRIPTION
Check that data member is correct type (ie: has been initialised) before attempting a comparison.