### PR TITLE
Fix running on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,9 @@
-FROM python:2.7
-
-RUN apt-get update && apt-get install -y wget
+FROM ecarrara/python-gdal
 
 ENV DOCKERIZE_VERSION v0.5.0
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-RUN apt-get install -y libgdal-dev
-RUN pip install --global-option=build_ext --global-option="-I/usr/include/gdal" gdal==1.10
 
 ADD /geokey/local_settings /app/local_settings
 ADD /geokey /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ecarrara/python-gdal
 
-ENV DOCKERIZE_VERSION v0.5.0
+ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz


### PR DESCRIPTION
For some (unknown to me - but due to GDAL installation) reason GeoKey was not running inside Docker anymore - container could not be built.

I had to switch to a container that provides GDAL already.

If you know a better solution - please let me know.

P.S. Updated Dockerize to the latest version.