### PR TITLE
Do not expose geokey-communitymaps extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,8 @@ RUN pip install --global-option=build_ext --global-option="-I/usr/include/gdal" 
 
 ADD /geokey/local_settings /app/local_settings
 ADD /geokey /app
-# Uncomment for communitymaps.
-# ADD /geokey-communitymaps /extensions/geokey-communitymaps
 
 WORKDIR /app
 RUN pip install -r requirements.txt
 RUN pip install -r requirements-dev.txt
 RUN pip install -e /app
-# Uncomment for communitymaps.
-# RUN pip install -e /extensions/geokey-communitymaps


### PR DESCRIPTION
Both Community Maps webapp and geokey-communitymaps extension are private projects that are not exposed to anyone apart Mapping for Change. However GeoKey is an open source project. We should not expose any connection between these two projects.