### PR TITLE
[Bugfix] Display site domain (and site name) correctly within emails

### DIFF
--- a/geokey/templates/account/email/email_confirmation_message.txt
+++ b/geokey/templates/account/email/email_confirmation_message.txt
@@ -1,6 +1,6 @@
 Dear {{ user.display_name }},
 
-{% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with current_site.name as site_name %}User {{ user_display }} at {{ site_name }} has given this as an email address.
+{% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name %}User {{ user_display }} at {{ site_name }} has given this as an email address.
 
 To confirm this is correct, go to {{ activate_url }}
 {% endblocktrans %}{% endautoescape %}

--- a/geokey/templates/account/email/password_reset_key_message.txt
+++ b/geokey/templates/account/email/password_reset_key_message.txt
@@ -1,6 +1,6 @@
 Dear {{ user.display_name }},
 
-{% load i18n %}{% blocktrans with site.domain as site_domain %}You're receiving this e-mail because you or someone else has requested a password for your user account at {{site_domain}}. 
+{% load i18n %}{% blocktrans with site_domain=current_site.domain %}You're receiving this e-mail because you or someone else has requested a password for your user account at {{site_domain}}.
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
 
 {{ password_reset_url }}

--- a/geokey/templates/account/email/password_reset_key_message.txt
+++ b/geokey/templates/account/email/password_reset_key_message.txt
@@ -7,4 +7,4 @@ It can be safely ignored if you did not request a password reset. Click the link
 
 {% if username %}{% blocktrans %}In case you forgot, your username is {{ username }}.{% endblocktrans %}
 
-{% endif %}{% trans 'Thanks for using our site!' %}
+{% endif %}{% blocktrans with site_name=current_site.name %}Thanks for using {{site_name}}!{% endblocktrans %}


### PR DESCRIPTION
I think the bug was introduced during django-allauth lib update some time ago. Seems like the way site metadata is accessed has changed...