### PR TITLE
[Bugfix] Correctly install dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
-Django>=1.8.19,<1.9
 factory-boy==2.11.1
 django-debug-toolbar==1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,3 @@ facebook-sdk==2.0.0
 oauth2client==4.1.2
 oauthlib==2.0.6
 google-api-python-client==1.6.4
-factory-boy==2.10.0


### PR DESCRIPTION
When using a Docker, Django 1.11 was installed from requirements.txt but then overriden to 1.8 by requirements-dev.txt - this is wrong.

Also, factory-boy is used only for testing, no need for production installation...