### PR TITLE
[Bugfix] Correctly add/remove project admins when project is locked

### DIFF
--- a/geokey/projects/tests/test_views.py
+++ b/geokey/projects/tests/test_views.py
@@ -694,6 +694,23 @@ class ProjectAdminsTest(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_add_on_locked_project(self):
+        self.project.islocked = True
+        self.project.save()
+
+        request = self.factory.post(
+            '/ajax/projects/%s/admins/' % self.project.id,
+            {'user_id': self.user_to_add.id}
+        )
+        force_authenticate(request, user=self.admin)
+        view = ProjectAdmins.as_view()
+        response = view(
+            request,
+            project_id=self.project.id
+        ).render()
+
+        self.assertEqual(response.status_code, 400)
+
     def test_add_when_user_already_an_admin(self):
         Admins.objects.create(project=self.project, user=self.user_to_add)
         request = self.factory.post(
@@ -790,7 +807,26 @@ class ProjectAdminsUserTest(TestCase):
             project_id=self.project.id,
             user_id=user.id
         ).render()
+
         self.assertEqual(response.status_code, 404)
+
+    def test_delete_on_locked_project(self):
+        self.project.islocked = True
+        self.project.save()
+
+        request = self.factory.delete(
+            '/ajax/projects/%s/admins/%s/' %
+            (self.project.id, self.admin_to_remove.id)
+        )
+        force_authenticate(request, user=self.admin)
+        view = ProjectAdminsUser.as_view()
+        response = view(
+            request,
+            project_id=self.project.id,
+            user_id=self.admin_to_remove.id
+        ).render()
+
+        self.assertEqual(response.status_code, 400)
 
     def test_delete_adminuser_with_admin(self):
         request = self.factory.delete(

--- a/geokey/projects/views.py
+++ b/geokey/projects/views.py
@@ -417,7 +417,8 @@ class ProjectAdmins(APIView):
 
         if project.islocked:
             return Response(
-                'The project is locked. New administrators cannot be added.',
+                {'error': 'The project is locked. New administrators cannot ' +
+                    'be added.'},
                 status=status.HTTP_400_BAD_REQUEST
             )
         else:
@@ -425,8 +426,8 @@ class ProjectAdmins(APIView):
                 user = User.objects.get(pk=request.data.get('user_id'))
             except User.DoesNotExist:
                 return Response(
-                    'The user you are trying to add to the group of ' +
-                    'administrators does not exist.',
+                    {'error': 'The user you are trying to add to the group ' +
+                        'of administrators does not exist.'},
                     status=status.HTTP_404_NOT_FOUND
                 )
 
@@ -434,7 +435,8 @@ class ProjectAdmins(APIView):
                 Admins.objects.create(project=project, user=user)
             except IntegrityError:
                 return Response(
-                    'The user is already an administrator of this project.',
+                    {'error': 'The user is already an administrator of this ' +
+                        'project.'},
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
@@ -476,7 +478,8 @@ class ProjectAdminsUser(APIView):
 
         if project.islocked:
             return Response(
-                'The project is locked. Administrators cannot be removed.',
+                {'error': 'The project is locked. Administrators cannot be ' +
+                    'removed.'},
                 status=status.HTTP_400_BAD_REQUEST
             )
         else:

--- a/geokey/templates/snippets/usergroup_editor.html
+++ b/geokey/templates/snippets/usergroup_editor.html
@@ -22,7 +22,9 @@
     	{% for user in users %}
     		<li>
     			{{ user }}
-    			{% if users|length > 1 or not admins and not project.islocked %}<a class="text-danger remove" data-user-id="{{ user.id }}" href="#"><small>remove</small></a>{% endif %}
+                {% if not project.islocked %}
+                    {% if users|length > 1 or not admins %}<a class="text-danger remove" data-user-id="{{ user.id }}" href="#"><small>remove</small></a>{% endif %}
+                {% endif %}
     		</li>
     	{% empty %}
     		<li>No users have been added to this user group yet.</li>

--- a/geokey/users/tests/test_ajax_views.py
+++ b/geokey/users/tests/test_ajax_views.py
@@ -321,6 +321,25 @@ class UserGroupSingleUserTest(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_delete_on_locked_project(self):
+        self.project.islocked = True
+        self.project.save()
+
+        request = self.factory.delete(
+            '/ajax/projects/%s/usergroups/%s/users/%s/' %
+            (self.project.id, self.contributors.id, self.contrib_to_remove.id),
+        )
+        force_authenticate(request, user=self.admin)
+        view = UserGroupSingleUser.as_view()
+        response = view(
+            request,
+            project_id=self.project.id,
+            usergroup_id=self.contributors.id,
+            user_id=self.contrib_to_remove.id
+        ).render()
+
+        self.assertEqual(response.status_code, 400)
+
     def test_delete_contributor_with_admin(self):
         request = self.factory.delete(
             '/ajax/projects/%s/usergroups/%s/users/%s/' %

--- a/geokey/users/tests/test_ajax_views.py
+++ b/geokey/users/tests/test_ajax_views.py
@@ -188,7 +188,7 @@ class UserGroupUsersTest(TestCase):
             usergroup_id=self.contributors.id
         ).render()
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 404)
 
     def test_add_on_locked_project(self):
         self.project.islocked = True

--- a/geokey/users/views.py
+++ b/geokey/users/views.py
@@ -806,10 +806,8 @@ class UserGroupUsers(APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
         else:
-            user_id = request.data.get('user_id')
-
             try:
-                user = User.objects.get(pk=user_id)
+                user = User.objects.get(pk=request.data.get('user_id'))
             except User.DoesNotExist:
                 return Response(
                     'The user you are trying to add to the user group does ' +

--- a/geokey/users/views.py
+++ b/geokey/users/views.py
@@ -812,7 +812,7 @@ class UserGroupUsers(APIView):
                 return Response(
                     'The user you are trying to add to the user group does ' +
                     'not exist.',
-                    status=status.HTTP_400_BAD_REQUEST
+                    status=status.HTTP_404_NOT_FOUND
                 )
 
             group = project.usergroups.get(pk=usergroup_id)

--- a/geokey/users/views.py
+++ b/geokey/users/views.py
@@ -754,7 +754,8 @@ class UserGroup(APIView):
 
         if project.islocked:
             return Response(
-                'The project is locked. User group info cannot be modified.',
+                {'error': 'The project is locked. User group info cannot be ' +
+                    'modified.'},
                 status=status.HTTP_400_BAD_REQUEST
             )
         else:
@@ -802,7 +803,7 @@ class UserGroupUsers(APIView):
 
         if project.islocked:
             return Response(
-                'The project is locked. New users cannot be added.',
+                {'error': 'The project is locked. New users cannot be added.'},
                 status=status.HTTP_400_BAD_REQUEST
             )
         else:
@@ -810,8 +811,8 @@ class UserGroupUsers(APIView):
                 user = User.objects.get(pk=request.data.get('user_id'))
             except User.DoesNotExist:
                 return Response(
-                    'The user you are trying to add to the user group does ' +
-                    'not exist.',
+                    {'error': 'The user you are trying to add to the user ' +
+                        'group does not exist.'},
                     status=status.HTTP_404_NOT_FOUND
                 )
 
@@ -854,7 +855,7 @@ class UserGroupSingleUser(APIView):
 
         if project.islocked:
             return Response(
-                'The project is locked. Users cannot be removed.',
+                {'error': 'The project is locked. Users cannot be removed.'},
                 status=status.HTTP_400_BAD_REQUEST
             )
         else:


### PR DESCRIPTION
This fixes:
- adding/removing project admins when project is locked
- error messages when modifying user group (incl. project admins)
- uses correct response code (404) when user is not found