### PR TITLE
[Bugfix] Correctly count num of media and comments

### DIFF
--- a/geokey/contributions/migrations/0020_update_media_and_comments_count.py
+++ b/geokey/contributions/migrations/0020_update_media_and_comments_count.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+
+
+def update_media_and_comments_count(apps, schema_editor):
+    Observation = apps.get_model('contributions', 'Observation')
+
+    for observation in Observation.objects.all():
+        observation.num_media = observation.files_attached.count()
+        observation.num_comments = observation.comments.count()
+        observation.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0019_auto_20181020_1915'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_media_and_comments_count)
+    ]

--- a/geokey/contributions/models.py
+++ b/geokey/contributions/models.py
@@ -518,10 +518,11 @@ class AudioFile(MediaFile):
 @receiver(post_save)
 def post_save_count_update(sender, instance, created, **kwargs):
     """
-    Receiver that is called after a media file or a comment is saved. Updates
-    num_media and num_comments properties.
+    Receiver that is called after a media file or a comment is created or
+    deleted. Updates num_media and num_comments properties of an observation.
     """
-    if created:
+    deleted = hasattr(instance, 'status') and instance.status == 'deleted'
+    if created or deleted:
         if sender.__name__ == 'Comment':
             instance.commentto.update_count()
         elif sender.__name__ in [

--- a/geokey/contributions/tests/comments/test_models.py
+++ b/geokey/contributions/tests/comments/test_models.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from nose.tools import raises
 
-from geokey.contributions.models import Comment, post_save_comment_count_update
+from geokey.contributions.models import Comment, post_save_count_update
 from ..model_factories import ObservationFactory, CommentFactory
 
 
@@ -17,9 +17,14 @@ class TestCommentPostSave(TestCase):
             'status': 'deleted'
         })
 
-        post_save_comment_count_update(Comment, instance=comment)
-        self.assertEqual(comment.commentto.num_media, 0)
-        self.assertEqual(comment.commentto.num_comments, 5)
+        post_save_count_update(
+            Comment,
+            instance=comment,
+            created=True)
+
+        observation.refresh_from_db()
+        self.assertEqual(observation.num_media, 0)
+        self.assertEqual(observation.num_comments, 5)
 
 
 class CommentTest(TestCase):

--- a/geokey/contributions/tests/media/test_models.py
+++ b/geokey/contributions/tests/media/test_models.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from geokey.contributions.models import (
     ImageFile, DocumentFile, VideoFile, AudioFile,
-    post_save_media_file_count_update
+    post_save_count_update
 )
 from geokey.contributions.tests.model_factories import ObservationFactory
 from geokey.contributions.tests.media.helpers.document_helpers import (
@@ -34,9 +34,14 @@ class TestImageFilePostSave(TestCase):
             image=get_image()
         )
 
-        post_save_media_file_count_update(ImageFile, instance=image_file)
-        self.assertEqual(image_file.contribution.num_media, 1)
-        self.assertEqual(image_file.contribution.num_comments, 0)
+        post_save_count_update(
+            ImageFile,
+            instance=image_file,
+            created=True)
+
+        observation.refresh_from_db()
+        self.assertEqual(observation.num_media, 1)
+        self.assertEqual(observation.num_comments, 0)
 
 
 class ImageFileTest(TestCase):
@@ -81,9 +86,14 @@ class TestDocumentFilePostSave(TestCase):
             document=get_pdf_document()
         )
 
-        post_save_media_file_count_update(DocumentFile, instance=document_file)
-        self.assertEqual(document_file.contribution.num_media, 1)
-        self.assertEqual(document_file.contribution.num_comments, 0)
+        post_save_count_update(
+            DocumentFile,
+            instance=document_file,
+            created=True)
+
+        observation.refresh_from_db()
+        self.assertEqual(observation.num_media, 1)
+        self.assertEqual(observation.num_comments, 0)
 
 
 class DocumentFileTest(TestCase):
@@ -132,9 +142,14 @@ class TestVideoFilePostSave(TestCase):
             swf_link='http://example.com/1122323.swf'
         )
 
-        post_save_media_file_count_update(VideoFile, instance=video_file)
-        self.assertEqual(video_file.contribution.num_media, 1)
-        self.assertEqual(video_file.contribution.num_comments, 0)
+        post_save_count_update(
+            VideoFile,
+            instance=video_file,
+            created=True)
+
+        observation.refresh_from_db()
+        self.assertEqual(observation.num_media, 1)
+        self.assertEqual(observation.num_comments, 0)
 
 
 class VideoFileTest(TestCase):
@@ -183,9 +198,14 @@ class TestAudioFilePostSave(TestCase):
             audio=get_image()
         )
 
-        post_save_media_file_count_update(AudioFile, instance=audio_file)
-        self.assertEqual(audio_file.contribution.num_media, 1)
-        self.assertEqual(audio_file.contribution.num_comments, 0)
+        post_save_count_update(
+            AudioFile,
+            instance=audio_file,
+            created=True)
+
+        observation.refresh_from_db()
+        self.assertEqual(observation.num_media, 1)
+        self.assertEqual(observation.num_comments, 0)
 
 
 class AudioFileTest(TestCase):

--- a/geokey/contributions/tests/test_serializers.py
+++ b/geokey/contributions/tests/test_serializers.py
@@ -428,6 +428,7 @@ class ContributionSerializerIntegrationTests(TestCase):
         CommentFactory.create(**{
             'commentto': observation
         })
+        observation.refresh_from_db()
         serializer = ContributionSerializer(
             observation,
             context={'user': self.contributor, 'project': self.project}

--- a/geokey/superusertools/tests/test_views.py
+++ b/geokey/superusertools/tests/test_views.py
@@ -325,6 +325,7 @@ class ManageProjectsTest(TestCase):
         self.assertEqual(len(context.get('projects')), 4)
 
         for project in context.get('projects'):
+            project.refresh_from_db()
             self.assertEqual(project.contributions_count, 1)
             self.assertEqual(project.comments_count, 1)
             self.assertEqual(project.media_count, 0)


### PR DESCRIPTION
## Root cause
Number of media files and comments added were calculated on an instance that was not up-to-date, causing a number being set wrongly.

## Solution
Before calculating both media files and comments - refresh instance so it's up to date and includes newly added relations.